### PR TITLE
fix(docker): upgrade pip/setuptools/wheel to clear Trivy toolchain CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
+# Upgrade the base image's Python packaging toolchain. python:3.11-slim ships
+# with pip 24.0 / setuptools / wheel that Trivy flags for wheel/archive-unpacking
+# CVEs. Not runtime-exploitable here (deps are installed once at build from our
+# own pyproject.toml, never untrusted packages), but upgrading clears the alerts.
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
 # Create non-root user
 RUN groupadd -g 10001 evoseal \
  && useradd -m -u 10001 -g 10001 -s /bin/bash evoseal


### PR DESCRIPTION
## What

Add `RUN pip install --no-cache-dir --upgrade pip setuptools wheel` to the root `Dockerfile`, right after the apt install block.

## Why

The Trivy scan that now runs on `main` (via the recently-landed `trivy-action@v0.36.0` bump, #43) surfaced 7 code-scanning alerts, all in the Python packaging toolchain baked into `python:3.11-slim`:

| Alert | Package | Severity |
|---|---|---|
| #1031 | wheel 0.45.1 | High |
| #1025 | jaraco.context 5.3.0 (vendored by setuptools) | High |
| #1029, #1028, #1027, #1026, #1030 | pip 24.0 | High → Low |

All share a single attack vector: **installing a crafted/malicious wheel or archive**. This image installs dependencies **once at build time** from our own `pyproject.toml` (never untrusted packages at runtime), so the CVEs are **not runtime-exploitable here** — but upgrading the toolchain clears the alerts and is safe (build-time tooling only).

Upgrading resolves the 5 pip alerts and the jaraco.context alert (via newer setuptools). The wheel alert may persist if no fixed release exists yet; if so it'll be dismissed separately as "not affected".

## Verification

- CI "Build and Scan Container" job re-runs Trivy on this PR's image and should show the alert set shrink.
- No application code touched; deps still install identically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Python packaging tools during the container build process.
  * Improved the reliability of subsequent dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->