### PR TITLE
chore(pre-commit): sync ruff-pre-commit pin with CI (v0.8.0 → v0.15.15)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
 
   # Ruff: replaces black, isort, flake8, and pylint
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.15.15  # keep in sync with the ruff version used by CI
     hooks:
       - id: ruff
         args: [--fix]

--- a/tests/integration/openevolve/test_openevolve_controller.py
+++ b/tests/integration/openevolve/test_openevolve_controller.py
@@ -53,7 +53,6 @@ try:
                 sys.path.insert(0, path)
 
         # Import the openevolve package
-        import openevolve
         from openevolve.config import Config, LLMConfig, LLMModelConfig, PromptConfig, load_config
 
         # Now import the specific modules we need
@@ -63,6 +62,8 @@ try:
         from openevolve.evaluator import Evaluator
         from openevolve.llm.ensemble import LLMEnsemble
         from openevolve.prompt.sampler import PromptSampler
+
+        import openevolve
 
         # Mock setup_logging since it's not available in the utils package
         def setup_logging(*args, **kwargs):

--- a/tests/integration/openevolve/test_openevolve_integration.py
+++ b/tests/integration/openevolve/test_openevolve_integration.py
@@ -13,9 +13,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from typer.testing import CliRunner
-
 from evoseal.integration.openevolve.cli.main import app
+from typer.testing import CliRunner
 
 # Constants for test values
 GENERATIONS = 5
@@ -250,9 +249,9 @@ def test_fitness_calculation(test_project: Path, metric: str, weight: float):
 
         # Verify the score is calculated correctly
         expected_score = individual.fitness[metric] * weight
-        assert score == pytest.approx(
-            expected_score, abs=1e-6
-        ), f"Fitness score not correctly weighted for {metric}"
+        assert score == pytest.approx(expected_score, abs=1e-6), (
+            f"Fitness score not correctly weighted for {metric}"
+        )
 
     except ImportError as e:
         pytest.skip(f"Could not import OpenEvolve components: {e}")


### PR DESCRIPTION
## Problem

The `ruff-pre-commit` hook was pinned at **v0.8.0** while the project and CI run **ruff 0.15.15**. The two versions format code differently, so running the hooks would reformat ~14 files on commit into a style that CI's `ruff format --check .` then **rejects** — i.e. pre-commit actively fought CI. (Surfaced while setting up the hooks locally via `pre-commit run --all-files`.)

## Changes

1. **`chore:`** bump `ruff-pre-commit` `v0.8.0` → `v0.15.15` so local hooks and CI use the same ruff. After the bump, `ruff`/`ruff-format` hooks agree with CI on all discovered files.
2. **`style:`** sort imports (ruff I001) in two `tests/integration/openevolve/` files. These sit under a dir that ruff's tree-walk prunes via the `openevolve/*` exclude, so CI never lints them — but pre-commit passes them explicitly and flagged a genuine unsorted-import block. Fixing makes `pre-commit run --all-files` clean.

## Verification (local)

- `pre-commit run ruff --all-files` → **Passed**; `ruff-format` → **Passed**
- CI parity intact: `ruff format --check .` → 282 files clean · `ruff check evoseal/ tests/` → All checks passed
- `pre-commit run --all-files` full pass (462 unit tests via the `pytest-check` hook)

## Note (not fixed here)

- The `openevolve/*` exclude in `pyproject.toml` unintentionally matches **`tests/integration/openevolve/`** as well as the root submodule, so those tests are silently skipped by CI's ruff. Left as-is to keep this PR scoped; worth tightening separately if you want CI to lint them.
- `trufflehog` (pre-push hook, `language: system`) is **not installed** locally — pushes will fail the pre-push hook until it's on PATH (or bypass with `--no-verify`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Ruff tooling to align pre-commit checks with the newer version used in CI.

* **Tests**
  * Improved integration test import handling for OpenEvolve availability checks.
  * Reordered test imports and reformatted a fitness score assertion without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->