### PR TITLE
fix: anchor submodule .gitignore entries so CI lints nested integration code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,10 +193,15 @@ out/
 # EVOSEAL runtime state (pipeline state, rollback targets, logs)
 .evoseal/
 
-# Submodule directories (tracked as gitlinks — listed here for tooling clarity)
-dgm/
-openevolve/
-SEAL/
+# Submodule directories (tracked as gitlinks — listed here for tooling clarity).
+# Anchored to the repo root: an unanchored "openevolve/" matches a dir of that
+# name at ANY depth, and ruff/other gitignore-respecting tools then silently skip
+# tracked package code and tests under evoseal/integration/{dgm,openevolve} and
+# tests/integration/{dgm,openevolve}. The leading slash confines the ignore to
+# the top-level submodules.
+/dgm/
+/openevolve/
+/SEAL/
 
 # Local tooling state
 .claude-plugin/


### PR DESCRIPTION
## Problem

The `.gitignore` entries for the submodules were **unanchored**:

```gitignore
dgm/
openevolve/
SEAL/
```

Under gitignore semantics an unanchored `openevolve/` matches a directory of that name **at any depth**, not just at the repo root. Ruff (and any other tool that respects `.gitignore`, which ruff does by default) therefore pruned the same-named *nested* directories during tree-walk discovery — silently hiding tracked code from CI's `ruff check evoseal/ tests/`:

- `evoseal/integration/dgm`
- `evoseal/integration/openevolve`
- `evoseal/prompt_templates/dgm`
- `tests/integration/dgm`
- `tests/integration/openevolve`

The first three are **real package code**, not just tests. None of them were being linted.

## Root cause (measured, not assumed)

A probe file dropped into `tests/integration/openevolve/` is flagged when ruff points at the dir directly, but invisible under `ruff check evoseal/ tests/`. Toggling `--no-respect-gitignore` makes it reappear — proving `.gitignore`, not the `[tool.ruff] exclude` glob, was the cause. (The `exclude` glob `openevolve/*` only ever excluded the root submodule; it never pruned nested dirs.)

## Fix

Anchor the three entries to the repo root so the ignore is confined to the top-level submodule gitlinks:

```gitignore
/dgm/
/openevolve/
/SEAL/
```

One-file change. The submodules are tracked as gitlinks and are unaffected.

## Verification

- `ruff format --check .` → pass (292 files)
- `ruff check evoseal/ tests/` → pass (newly-visible files are already clean under the project's `E4`/`I001` rules)
- Top-level `dgm/`, `openevolve/`, `SEAL/` remain excluded from linting.
- Probe confirms the nested dirs are now covered by CI's exact invocation.

Side benefit: `git add tests/integration/openevolve/…` no longer needs `-f`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined ignore rules for selected top-level directories.
  * Added clearer guidance explaining how directory matching works.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->