### PR TITLE
fix(seal): atomic KnowledgeBase.save_to_disk + de-flake test_concurrent_access (closes #45)

### DIFF
--- a/evoseal/integration/seal/knowledge/knowledge_base.py
+++ b/evoseal/integration/seal/knowledge/knowledge_base.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import tempfile
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -57,7 +58,6 @@ class KnowledgeBase:
     SAVE_LOCK_TIMEOUT = 2  # seconds
     MAX_RETRIES = 3
     DEFAULT_SEARCH_LIMIT = 10
-    RETRY_BACKOFF_BASE = 0.1  # seconds
     SAVE_RETRY_BACKOFF_BASE = 0.2  # seconds
     JSON_INDENT = 2
 
@@ -313,59 +313,45 @@ class KnowledgeBase:
         if not save_path:
             raise ValueError("No storage path provided")
 
-        # Create a snapshot without holding the lock for too long
-        entries_snapshot = {}
+        # Snapshot the entries under the in-memory lock. If the lock cannot be
+        # acquired, abort the save rather than writing an empty snapshot over
+        # previously persisted data.
+        if not self._lock.acquire(timeout=self.SAVE_LOCK_TIMEOUT):
+            raise RuntimeError("Could not acquire lock to snapshot entries for save")
         try:
-            # Use a non-blocking lock acquisition with timeout
-            if self._lock.acquire(timeout=self.SAVE_LOCK_TIMEOUT):
-                try:
-                    # Create a deep copy of entries to avoid race conditions during serialization
-                    for entry_id, entry in self.entries.items():
-                        entries_snapshot[entry_id] = entry.model_copy(deep=True)
-                finally:
-                    self._lock.release()
-            else:
-                # If we couldn't get the lock, log a warning and continue with empty snapshot
-                print("WARNING: Could not acquire lock for reading entries, using empty snapshot")
-        except Exception as e:
-            print(f"Error acquiring lock: {e}")
-            # Continue with whatever entries we have
+            entries_snapshot = {
+                entry_id: entry.model_copy(deep=True) for entry_id, entry in self.entries.items()
+            }
+        finally:
+            self._lock.release()
 
-        # Then perform file operations
+        data = {"entries": [entry.model_dump() for entry in entries_snapshot.values()]}
+
+        # Write to a temporary file in the same directory, then atomically
+        # replace the target with os.replace(). This guarantees the target is
+        # never truncated in place: a concurrent or failed save can never leave
+        # it empty or half-written. Racing writers may still overwrite one
+        # another's additions (last writer wins), but committed data is never
+        # destroyed. The previous implementation opened the target with mode "w"
+        # (truncating it) *before* taking the file lock, so a lost race wiped the
+        # file entirely -- see issue #45.
+        save_path_abs = os.path.abspath(save_path)
+        directory = os.path.dirname(save_path_abs)
+        os.makedirs(directory, exist_ok=True)
+
+        fd, tmp_path = tempfile.mkstemp(prefix=".kb-", suffix=".tmp", dir=directory)
         try:
-            # Ensure directory exists
-            os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
-
-            # Use exclusive lock for writing, but with a timeout
-            with open(save_path, "w") as f:
-                # Use non-blocking lock with retry
-                max_retries = 3
-                for retry in range(max_retries):
-                    try:
-                        # Try to get a non-blocking lock
-                        fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                        try:
-                            data = {
-                                "entries": [
-                                    entry.model_dump() for entry in entries_snapshot.values()
-                                ]
-                            }
-                            json.dump(data, f, indent=self.JSON_INDENT, default=str)
-                            f.flush()  # Flush to OS buffer
-                            os.fsync(f.fileno())  # Force OS to write to disk
-                            break  # Successfully wrote data, exit retry loop
-                        finally:
-                            fcntl.flock(f.fileno(), fcntl.LOCK_UN)  # Release lock
-                    except OSError as e:
-                        if retry < max_retries - 1:
-                            # Wait a bit before retrying
-                            time.sleep(self.RETRY_BACKOFF_BASE * (retry + 1))
-                        else:
-                            # On last retry, raise the exception
-                            raise RuntimeError(
-                                f"Could not acquire file lock after {max_retries} retries"
-                            ) from e
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f, indent=self.JSON_INDENT, default=str)
+                f.flush()  # Flush to OS buffer
+                os.fsync(f.fileno())  # Force OS to write to disk before rename
+            os.replace(tmp_path, save_path_abs)  # Atomic on POSIX
         except Exception as e:
+            # Never leave the temp file behind or touch the target on failure.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
             raise RuntimeError(f"Failed to save knowledge base: {e}") from e
 
     def load_from_disk(self, path: str | Path) -> None:

--- a/tests/integration/seal/test_knowledge_base_concurrent.py
+++ b/tests/integration/seal/test_knowledge_base_concurrent.py
@@ -2,7 +2,6 @@
 Concurrent and performance tests for the KnowledgeBase component.
 """
 
-import concurrent.futures
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
@@ -77,45 +76,24 @@ def _run_workers_sequentially(num_workers: int, db_path: Path) -> list[tuple[str
 def _run_workers_concurrently(
     num_workers: int, db_path: Path
 ) -> list[tuple[str, list[tuple[str, str, str]]]]:
-    """Run multiple workers concurrently with a strict timeout."""
+    """Run multiple workers concurrently and collect every worker's result.
+
+    Each worker does a bounded amount of trivial work (one add + one save), so
+    we wait for all of them to finish rather than imposing a wall-clock budget.
+    An earlier version cancelled workers that missed a fixed 10s deadline, which
+    measured machine load (xdist saturation under ``pytest -n auto``) rather than
+    the code under test and made this test flaky. The only reason a worker would
+    not return here is a genuine deadlock, which the test-level timeout guards.
+    """
     results = []
+    start_time = time.time()
     with ThreadPoolExecutor(max_workers=num_workers) as executor:
-        # Submit tasks
-        futures = []
-        for i in range(num_workers):
-            futures.append(executor.submit(_worker_operation, i, db_path))
-
-        # Use a very short timeout to avoid hanging
-        timeout_seconds = 10
-        start_time = time.time()
-
-        # Wait for completion with timeout
-        try:
-            # First wait for all futures with a strict timeout
-            done, not_done = concurrent.futures.wait(
-                futures,
-                timeout=timeout_seconds,
-                return_when=concurrent.futures.ALL_COMPLETED,
-            )
-
-            # Process completed futures
-            for future in done:
-                try:
-                    results.append(future.result(timeout=1))
-                except Exception as e:
-                    print(f"Error in worker: {e}")
-
-            # Cancel any remaining futures
-            for future in not_done:
-                future.cancel()
-                print("Cancelled a worker that didn't complete in time")
-
-        except Exception as e:
-            print(f"Exception in concurrent execution: {e}")
-            # Cancel all futures to prevent hanging
-            for future in futures:
-                if not future.done():
-                    future.cancel()
+        futures = [executor.submit(_worker_operation, i, db_path) for i in range(num_workers)]
+        # _worker_operation swallows its own exceptions and returns an error
+        # tuple, so result() will not raise; _verify_worker_results asserts that
+        # each worker reported "completed".
+        for future in as_completed(futures):
+            results.append(future.result())
 
     print(f"Concurrent workers completed in {time.time() - start_time:.2f} seconds")
     return results
@@ -156,7 +134,11 @@ def _verify_persisted_data(db_path: Path, num_workers: int) -> None:
     )
 
 
-@pytest.mark.timeout(30)  # Add a strict 30-second timeout to the entire test
+# Generous hang-guard, not a performance bound: the test does trivial work and
+# takes ~15s idle, but xdist saturation can stretch wall-clock well past a tuned
+# budget without any real problem. A large timeout only trips on a genuine
+# deadlock (see #45).
+@pytest.mark.timeout(180)
 def test_concurrent_access(tmp_path: Path):
     """Test concurrent access to the knowledge base with persistence verification."""
     # Create a subdirectory for the test to avoid permission issues
@@ -279,18 +261,33 @@ def test_concurrent_access(tmp_path: Path):
 
     print(f"Found {entries_found} out of {len(expected_entries)} expected entries")
 
-    # Verify we have entries from at least half of the workers
-    # This is a more reasonable expectation for concurrent operations
-    min_expected_workers = max(1, num_workers // 2)
-    assert len(worker_entries) >= min_expected_workers, (
-        f"Expected entries from at least {min_expected_workers} workers, got {len(worker_entries)}"
+    # Regression guard for issue #45: concurrent save_to_disk() must NEVER
+    # destroy already-committed data. Because save is now atomic (write temp +
+    # os.replace), every concurrent worker loads the committed state before
+    # rewriting, so the initial and sequential entries always survive the
+    # concurrent phase. The old truncate-before-lock implementation could wipe
+    # the whole file to zero entries here.
+    surviving_contents = {str(entry.content) for entry in entries}
+    missing_initial = [
+        f"Initial entry {i}"
+        for i in range(TEST_ENTRIES_COUNT)
+        if f"Initial entry {i}" not in surviving_contents
+    ]
+    assert not missing_initial, (
+        f"Concurrent saves destroyed committed initial entries: {missing_initial}"
+    )
+    missing_sequential = expected_sequential_entries - surviving_contents
+    assert not missing_sequential, (
+        f"Concurrent saves destroyed committed sequential entries: {missing_sequential}"
     )
 
-    # Verify we found at least some of the expected entries
-    min_expected_entries = max(1, len(expected_entries) // 4)  # At least 25% of expected entries
-    assert entries_found >= min_expected_entries, (
-        f"Found only {entries_found} out of {len(expected_entries)} expected entries"
+    # Individual *concurrent* writers may still overwrite one another's additions
+    # (last-writer-wins on the whole-file rewrite — lost updates, not corruption),
+    # so we only require that at least one concurrent worker's entry survived.
+    assert len(worker_entries) >= 1, (
+        f"Expected entries from at least one worker, got {len(worker_entries)}"
     )
+    assert entries_found >= 1, f"Found none of the {len(expected_entries)} expected worker entries"
 
     # Verify database file still exists and has content
     assert db_path.exists(), "Database file was deleted after test"


### PR DESCRIPTION
Closes #45.

## TL;DR

Investigating the `test_concurrent_access` flake (#45) turned up **two** failure modes — the one the issue documents (a load-sensitive wall-clock timeout) and a more serious one it misdiagnosed: **`KnowledgeBase.save_to_disk` could destroy already-committed data under concurrent saves**, zeroing the database ~5% of the time regardless of load. This PR fixes both.

## 1. Data-loss bug (production fix)

`save_to_disk()` did:

```python
with open(save_path, "w") as f:          # <-- truncates target to 0 bytes IMMEDIATELY
    fcntl.flock(f.fileno(), LOCK_EX | LOCK_NB)   # <-- lock acquired AFTER truncation
    ...
```

The target file was truncated **before** the lock was taken, so a writer that lost the race (or exhausted its lock retries) left the file **empty** — wiping every previously committed entry. A second path made it worse: if the in-memory snapshot lock timed out, the code wrote an **empty snapshot** over good data on purpose. (`fcntl.flock` is also per-process, so it never excluded threads within one process — which is exactly how this is used.)

**Fix:** write to a temp file in the same directory, `fsync`, then `os.replace()` over the target (atomic on POSIX). The target is never truncated in place and can never be observed empty or half-written. The snapshot path now **aborts** (raises, and the internal `_save_to_disk` wrapper retries/logs) instead of writing nothing. Concurrent writers may still overwrite one another's *additions* (last-writer-wins lost updates), but **committed data is never destroyed**.

## 2. Test flake (de-flake + regression guard)

- Removed the fixed 10s worker-cancellation deadline and raised the test-level `@pytest.mark.timeout` from a load-tuned 30s to a generous 180s hang-guard. The runner now simply waits for all workers (they do trivial bounded work); the only thing that trips the timeout is a real deadlock.
- Replaced the old best-effort `>=25% of entries` check with a real invariant enabled by the fix: **every initial and sequential entry must survive the concurrent phase**, with at least one concurrent worker's entry present. This directly guards the data-loss regression.

## Verification

- `test_knowledge_base.py`, `test_knowledge_base_concurrent.py`, `test_knowledge_aware_strategy.py` → **19 passed** (normal save/load/clear/update paths intact, incl. benchmarks).
- `test_concurrent_access` run **50×** under a deliberately saturated box (2× cores of CPU burn): **50/50 pass**. Before the save fix, the same loop failed ~1-in-20 by wiping the DB to 0 entries.
- `ruff format --check .` and `ruff check evoseal/ tests/` → pass. (These files sit under `evoseal/integration/seal/…` and `tests/integration/seal/…`; note #49 just restored CI ruff coverage for the sibling `…/openevolve` and `…/dgm` dirs.)