### PR TITLE
docs: add architecture decision records (ADRs)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -155,7 +155,7 @@
 
 ### Documentation Polish
 
-- [ ] **Add architecture decision records (ADRs)**
+- [x] **Add architecture decision records (ADRs)** _(done 2026-07-19)_
   - Why MAP-Elites over other evolutionary strategies?
   - Why SEAL over pure prompt engineering?
   - Why Git-based version control for self-edits?
@@ -188,8 +188,8 @@
 | 🔴 P0    | 5     | 5    | All complete as of 2026-06-04 |
 | 🟠 P1    | 10    | 9    | Safety config path gap open |
 | 🟡 P2    | 10    | 0    | In progress — see Plans.md Phase 3 (3.1-3.12) |
-| 🟢 P3    | 12    | 3    | Makefile, pre-commit, Docker complete |
-| **Total** | **37** | **17** | |
+| 🟢 P3    | 12    | 4    | Makefile, pre-commit, Docker, ADRs complete |
+| **Total** | **37** | **18** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/docs/adr/0002-map-elites-selection.md
+++ b/docs/adr/0002-map-elites-selection.md
@@ -1,0 +1,82 @@
+# ADR 0002 — MAP-Elites for candidate selection
+
+**Status:** Accepted
+**Date:** 2026-07-19
+**Context:** EVOSEAL needs a strategy for selecting which code variants survive
+across generations. The choice of selection algorithm directly affects convergence
+speed, solution diversity, and the risk of premature convergence.
+
+---
+
+## 1. Context
+
+EVOSEAL generates multiple code variants per generation and must decide which
+ones carry forward. The two fundamental tensions are:
+
+- **Exploitation** — keep the highest-fitness variants to converge quickly.
+- **Exploration** — maintain diverse variants to avoid getting stuck in local
+  optima.
+
+Classical evolutionary strategies (tournament selection, roulette wheel,
+elitism) lean toward exploitation. Pure random selection preserves diversity but
+ignores fitness. EVOSEAL needs a strategy that balances both, because
+self-modifying code can easily converge to a local optimum (a pipeline that
+"works" but is worse than alternatives it never explored).
+
+## 2. Decision
+
+Use **MAP-Elites** (Multi-dimensional Archive of Phenotypic Elites), a
+quality-diversity algorithm, as the primary selection mechanism in OpenEvolve.
+
+## 3. Rationale
+
+### Why MAP-Elites over alternatives
+
+| Alternative | Limitation | MAP-Elites advantage |
+|-------------|-----------|---------------------|
+| Tournament selection | Converges fast, loses diversity | MAP-Elites maintains an archive of elites across behavioral dimensions |
+| Roulette wheel | Fitness-proportional, still converges | MAP-Elites decouples fitness from behavioral characterization |
+| NSGA-II (multi-objective) | Pareto front doesn't guarantee coverage | MAP-Elites fills a behavioral grid, ensuring broad exploration |
+| Random selection | Ignores fitness entirely | MAP-Elites selects the best *within each niche* |
+
+### Why quality-diversity matters for self-modification
+
+In a self-modifying system, premature convergence is particularly dangerous:
+the system may lock into a suboptimal pipeline configuration and lose the
+ability to explore alternatives. MAP-Elites addresses this by:
+
+1. **Behavioral characterization** — variants are placed in a grid based on
+   behavioral features (not just fitness), so structurally different solutions
+   coexist.
+2. **Elitism within niches** — the best variant in each niche survives,
+   preserving both quality and diversity.
+3. **No explicit diversity penalty** — unlike NSGA-II, diversity is structural
+   (the grid) rather than a secondary objective to optimize.
+
+### What MAP-Elites is *not*
+
+- It is not a replacement for the fitness function — it organizes *how* fitness
+  is applied, not what fitness measures.
+- It does not guarantee global optima — it improves coverage, not convergence
+  speed in the limit.
+- It adds complexity (grid design, behavioral characterization) that simpler
+  strategies avoid.
+
+## 4. Consequences
+
+- **Positive:** Broader exploration of the variant space; reduced risk of
+  premature convergence; the archive itself is a useful artifact for analyzing
+  what the system explored.
+- **Negative:** Grid design requires choosing behavioral dimensions, which is
+  problem-dependent and non-trivial. Archive memory grows with grid resolution.
+- **Neutral:** MAP-Elites is implemented in OpenEvolve; EVOSEAL wraps it via
+  the integration layer.
+
+## 5. References
+
+- Mouret, J.-B. & Clune, J. (2015). *Illuminating Search Spaces by Mapping
+  Elites.* arXiv:1504.04909.
+- [`docs/architecture/overview.md`](../architecture/overview.md) — OpenEvolve
+  component description.
+- [`evoseal/core/selection.py`](../../evoseal/core/selection.py) — EVOSEAL's
+  selection wrapper.

--- a/docs/adr/0003-seal-over-prompt-engineering.md
+++ b/docs/adr/0003-seal-over-prompt-engineering.md
@@ -1,0 +1,100 @@
+# ADR 0003 — SEAL over pure prompt engineering
+
+**Status:** Accepted
+**Date:** 2026-07-19
+**Context:** EVOSEAL needs a mechanism for improving its own capabilities over
+time. The fundamental choice is between improving *prompts* (the instructions
+given to a fixed model) or improving the *model itself* (via fine-tuning). SEAL
+(Self-Adapting Language Models) provides the latter.
+
+---
+
+## 1. Context
+
+There are two broad approaches to making a language-model-based agent improve
+over time:
+
+1. **Prompt engineering** — refine the instructions, examples, and context
+   provided to a fixed model. No model weights change.
+2. **Model adaptation** — fine-tune the model's weights on data produced by the
+   evolution loop, so the model itself becomes better at the task.
+
+EVOSEAL originally used only prompt engineering (via DGM's prompt templates). As
+the system matured, it adopted SEAL to also support weight-level adaptation.
+
+## 2. Decision
+
+Use **SEAL (Self-Adapting Language Models)** as the model adaptation layer,
+alongside (not replacing) prompt-level improvements.
+
+## 3. Rationale
+
+### What SEAL provides that prompt engineering cannot
+
+| Capability | Prompt engineering | SEAL (fine-tuning) |
+|-----------|-------------------|-------------------|
+| Incorporate new knowledge | Limited to context window | Persists in model weights |
+| Few-shot adaptation | Works, but bounded by examples | Learns generalized patterns |
+| Self-modification capability | Changes instructions | Changes the model that interprets instructions |
+| Token efficiency | Prompts grow with examples | Learned behavior is "free" at inference time |
+
+### Why both, not one or the other
+
+EVOSEAL now supports **two co-evolution paths** that reflect this duality:
+
+1. **Prompt-level co-evolution (CPU-friendly, default)** — a coder model writes
+   code, a reviewer critiques it, and the feedback evolves the coder's *system
+   prompt*. No GPU required. This is pure prompt engineering, gated by
+   regression checks and rollback.
+
+2. **Weight-level fine-tuning (GPU-only)** — LoRA/QLoRA fine-tuning from
+   evolution data. This is the SEAL path. Requires a CUDA GPU.
+
+The prompt-level path was added *because* the weight-level path has practical
+barriers (GPU cost, training instability, model-specific tuning). The two paths
+are complementary:
+
+- Prompt-level is cheaper, faster, and reversible. Good for rapid iteration.
+- Weight-level is deeper, persists knowledge, and doesn't consume context
+  tokens. Good for durable improvements.
+
+### Why not pure prompt engineering
+
+Pure prompt engineering hits a ceiling:
+
+- **Context window limits.** As the system accumulates examples and rules, the
+  prompt grows until it exceeds the model's context window. Fine-tuning
+  compresses this knowledge into weights.
+- **No generalization.** Prompt-based examples teach by demonstration;
+  fine-tuning teaches by *pattern*, which generalizes to unseen cases.
+- **Token cost.** Every inference pays the full prompt cost. Learned behavior
+  is free after training.
+
+### Why not fine-tuning only
+
+Fine-tuning has its own limits:
+
+- **Requires GPU.** LoRA/QLoRA needs a CUDA GPU. Many EVOSEAL users run on CPU.
+- **Training instability.** Fine-tuning can degrade existing capabilities
+  (catastrophic forgetting) or amplify biases.
+- **Slower feedback loop.** Training takes minutes to hours; prompt changes take
+  seconds.
+- **Model-specific.** Fine-tuning is tied to a specific model architecture and
+  checkpoint. Prompts are model-agnostic.
+
+## 4. Consequences
+
+- **Positive:** The system can improve at two levels, choosing the right tool
+  for the situation. Prompt-level works on any hardware. Weight-level provides
+  durable knowledge incorporation.
+- **Negative:** Two adaptation paths mean two codepaths to maintain, two kinds
+  of versioning, and two rollback mechanisms.
+- **Neutral:** The prompt-level path is the default; the weight-level path is
+  opt-in for GPU-equipped users.
+
+## 5. References
+
+- [`docs/architecture/local_coevolution.md`](../architecture/local_coevolution.md) — prompt-level co-evolution design.
+- [`evoseal/fine_tuning/`](../../evoseal/fine_tuning/) — weight-level fine-tuning code.
+- [`evoseal/prompt_evolution/`](../../evoseal/prompt_evolution/) — prompt-level co-evolution code.
+- [`docs/examples/self_improvement_walkthrough.md`](../examples/self_improvement_walkthrough.md) — concrete before/after example.

--- a/docs/adr/0004-git-based-version-control.md
+++ b/docs/adr/0004-git-based-version-control.md
@@ -1,0 +1,105 @@
+# ADR 0004 — Git-based version control for self-edits
+
+**Status:** Accepted
+**Date:** 2026-07-19
+**Context:** EVOSEAL modifies its own codebase during evolution. It needs a
+mechanism for tracking changes, reverting failures, and maintaining a history of
+what the system looked like at each generation. The choice is between a custom
+versioning system and Git.
+
+---
+
+## 1. Context
+
+A self-modifying system must answer three questions after every edit:
+
+1. **What changed?** (diff inspection)
+2. **Can I go back?** (rollback)
+3. **What did the system look like at generation N?** (reproducibility)
+
+These are exactly the questions version control systems answer. The design
+choice is whether to use an existing VCS (Git) or build a custom one.
+
+## 2. Decision
+
+Use **Git** as the version control backbone for all self-modifications, backed
+by a checkpoint system that creates file-level snapshots for fast rollback.
+
+## 3. Rationale
+
+### Why Git over a custom versioning system
+
+| Concern | Custom system | Git |
+|---------|--------------|-----|
+| Diff inspection | Must build tooling | `git diff` — mature, well-understood |
+| Rollback | Must implement restore logic | `git checkout` / `git revert` |
+| History | Must design storage format | Commits, branches, tags — built-in |
+| Reproducibility | Must snapshot entire state | `git checkout <commit>` |
+| Tooling ecosystem | None | IDEs, CI, code review, blame |
+| Developer familiarity | Learning curve | Universal |
+
+### Why Git over a database-only approach
+
+EVOSEAL already uses SQLite for experiment tracking (`ExperimentDatabase`) and
+code archives (`CodeArchive`). Why add Git on top?
+
+- **Human-readable history.** Git history is browsable with standard tools.
+  A database requires custom queries.
+- **Atomic operations.** Git commits are atomic — either the full change lands
+  or nothing does. Database transactions can achieve this, but require explicit
+  implementation.
+- **Branching.** Evolution variants can live on branches. The main branch
+  always reflects the "accepted" state. This is a natural fit for the
+  generate → evaluate → select → accept workflow.
+- **Interoperability.** The code under modification is a Python package. Git is
+  the standard for Python project versioning. Using Git means the evolution
+  history is compatible with the broader ecosystem (CI, code review, etc.).
+
+### The checkpoint layer
+
+Git alone is not sufficient for fast rollback because:
+
+1. `git checkout` modifies the working tree, which can conflict with running
+   processes.
+2. Checkpoint *restoration* needs to be faster than a full Git operation for
+   the safety-critical rollback path.
+
+EVOSEAL adds a **CheckpointManager** on top of Git that:
+
+- Creates file-level snapshots (with SHA-256 integrity verification) before
+  every edit.
+- Restores via `shutil.copy2`/`copytree` — faster than `git checkout` and
+  doesn't mutate `.git/`.
+- Preserves `.git/` in `protected_dirs` so rollback never corrupts history.
+
+The result is a two-layer system: Git for history and human-readable diffs,
+checkpoints for fast, safe rollback.
+
+### What this does *not* provide
+
+- **No distributed versioning.** EVOSEAL is single-host. Git's distributed
+  features (push/pull/merge) are used for the *repo*, not for the evolution
+  history.
+- **No conflict resolution.** The evolution loop is single-threaded — it
+  applies one edit at a time. Merge conflicts don't arise.
+- **No Git-based rollback in the safety path.** The safety layer uses
+  checkpoint restoration, not `git reset`. This is deliberate — a failed
+  `git reset` can corrupt the working tree; a failed file copy is safer.
+
+## 4. Consequences
+
+- **Positive:** Evolution history is inspectable with standard Git tools. The
+  system benefits from Git's maturity (atomic commits, blame, bisect). CI/CD
+  integration is natural.
+- **Negative:** Git adds a dependency and some operational complexity
+  (submodule management, `.git/` protection during rollback).
+- **Neutral:** The checkpoint layer is a thin abstraction that could be swapped
+  without changing the Git-based history.
+
+## 5. References
+
+- [`evoseal/core/checkpoint_manager.py`](../../evoseal/core/checkpoint_manager.py) — checkpoint creation/restoration.
+- [`evoseal/core/rollback_manager.py`](../../evoseal/core/rollback_manager.py) — safe rollback with target validation.
+- [`evoseal/core/version_database.py`](../../evoseal/core/version_database.py) — version tracking.
+- [`docs/architecture/core/version_control_experiment_tracking.md`](../architecture/core/version_control_experiment_tracking.md) — version control architecture.
+- [`docs/safety/sandbox_design.md`](../safety/sandbox_design.md) — ADR 0001 (rollback vs sandbox decision).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,22 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for EVOSEAL. Each
+ADR documents a significant design decision, the context that led to it, and the
+trade-offs considered.
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [0001](../safety/sandbox_design.md) | Isolation strategy: rollback vs sandbox | Accepted | 2026-06-05 |
+| [0002](0002-map-elites-selection.md) | MAP-Elites for candidate selection | Accepted | 2026-07-19 |
+| [0003](0003-seal-over-prompt-engineering.md) | SEAL over pure prompt engineering | Accepted | 2026-07-19 |
+| [0004](0004-git-based-version-control.md) | Git-based version control for self-edits | Accepted | 2026-07-19 |
+
+## Conventions
+
+- ADRs are numbered sequentially (`NNNN-short-title.md`).
+- Status values: `Proposed`, `Accepted`, `Superseded`, `Deprecated`.
+- Once accepted, an ADR is not deleted — it is superseded by a newer ADR if the
+  decision changes.
+- Follow the template in each ADR for consistency.


### PR DESCRIPTION
## What

Adds three Architecture Decision Records documenting foundational design choices, plus an index file:

- **ADR 0002: MAP-Elites for candidate selection** — why quality-diversity over tournament/roulette/elitism; premature convergence risk in self-modifying systems; trade-offs (grid design complexity, memory).
- **ADR 0003: SEAL over pure prompt engineering** — context window ceiling, generalization, token cost as reasons for weight-level adaptation; why both prompt-level and weight-level paths coexist (CPU vs GPU, speed vs depth).
- **ADR 0004: Git-based version control for self-edits** — maturity, atomicity, human-readable history, ecosystem compatibility; the checkpoint layer on top for fast safe rollback.
- **`docs/adr/index.md`** — references the existing ADR 0001 (sandbox design at `docs/safety/sandbox_design.md`).

## Why

Addresses TODO.md item "Add architecture decision records (ADRs)" under P3 Documentation Polish. Makes the reasoning behind key design choices explicit for contributors.

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `docs/adr/index.md` | 22 | ADR index with links to all 4 ADRs |
| `docs/adr/0002-map-elites-selection.md` | 82 | MAP-Elites decision record |
| `docs/adr/0003-seal-over-prompt-engineering.md` | 100 | SEAL vs prompt engineering decision record |
| `docs/adr/0004-git-based-version-control.md` | 105 | Git-based version control decision record |
| `TODO.md` | +3/-3 | Checkbox flipped to done; tracking table updated (P3: 3→4, total: 17→18) |

## Verification

- `ruff format --check .` — 292 files already formatted ✅
- `ruff check evoseal/ tests/` — all checks passed ✅
- No Python code changed (4 new markdown files + 1 markdown edit)

## Note

Pre-commit pytest hook fails on a pre-existing DGM submodule import error (submodules not initialized in this worktree). Unrelated to markdown-only changes.