### PR TITLE
docs: file bidirectional co-evolution loop gaps in backlog

### DIFF
--- a/EVOLUTION.md
+++ b/EVOLUTION.md
@@ -17,6 +17,14 @@ backing model (Devstral via Ollama). The three sub-phases are:
 | Phase 2 | Fine-tuning infrastructure (`evoseal/fine_tuning/`) | Done |
 | Phase 3 | Continuous evolution service + dashboard (`evoseal/services/`) | Done |
 
+> **Maturity caveat (2026-07-19):** The Phase 3 *modules* are built, but the bidirectional
+> loop is not yet closed. Key gaps: the daemon simulates evolution instead of running the
+> pipeline; the training call has a method-name bug; model validation tests the baseline
+> model rather than fine-tuned weights; deployment only writes to a JSON registry with no
+> serving-layer integration; and the generator never consults the fine-tuning registry.
+> Phase 3 is therefore architectural scaffolding, not yet operational co-evolution.
+> See TODO.md ‘Close the bidirectional co-evolution loop’ for the specific gaps.
+
 ## Active goals (P2 — Medium Priority)
 
 These are the next priorities from [TODO.md](TODO.md):

--- a/TODO.md
+++ b/TODO.md
@@ -95,6 +95,22 @@
 
 ## 🟡 P2 — Medium Priority
 
+### Close the bidirectional co-evolution loop
+
+> **Audit finding (2026-07-19):** The Phase 3 components/modules exist, but the bidirectional
+> feedback edges are not wired. The daemon simulates evolution instead of running it, the
+> training call has a method-name bug, model validation tests the baseline instead of the
+> fine-tuned model, deployment is a JSON registry with no serving-layer integration, and the
+> generator never consults the fine-tuning registry. These items close those gaps.
+
+- [ ] **Wire daemon to real EvolutionPipeline** — `continuous_evolution_service.py:174` `_run_evolution_cycle` only reads `get_statistics()` and simulates; must invoke `EvolutionPipeline` instead
+- [ ] **FIX: training call uses nonexistent method** — `continuous_evolution_service.py:234` calls `training_manager.start_training()` which does not exist; the real method is `run_training_cycle` at `training_manager.py:195` → `AttributeError` if reached
+- [ ] **validate_model must serve the fine-tuned model, not baseline** — `model_validator.py:211,247,306,371,436` all use `OllamaProvider(model=self.baseline_model)`, ignoring the `model_path` argument; must load the fine-tuned model for validation
+- [ ] **Implement real model deployment** — `version_manager.register_version` only copies weights + sets `current_version` in a JSON registry; need actual deployment (Modelfile / `ollama create` / symlink) so the serving layer can load the model
+- [ ] **Generation must consult the fine-tuning registry** — `version_manager.get_current_version()` has zero callers; the generator (`integration/seal/*`, `evolution_pipeline.py`, `providers/local_models.py resolve_model`) must consult it to use the deployed fine-tuned model
+- [ ] **Add end-to-end bidirectional loop test** — exercise the full cycle: collect → train → validate → deploy → regenerate; no such test exists today
+- [ ] **Wire the loop into the CLI** — `evoseal start` (`cli/commands/start.py:39,57`) only has stubs (`"not yet implemented"`); must start the continuous evolution service and hook it into the pipeline
+
 ### Phase 3 (Bidirectional Evolution) Documentation
 
 - [ ] **Write architecture doc for Devstral co-evolution**
@@ -195,9 +211,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 5     | 5    | All complete as of 2026-06-04 |
 | 🟠 P1    | 11    | 9    | Safety config path gap + Tier 2 deferred open |
-| 🟡 P2    | 10    | 0    | In progress — see Plans.md Phase 3 (3.1-3.12) |
+| 🟡 P2    | 17    | 0    | Co-evolution loop gaps (7 items) + existing P2 |
 | 🟢 P3    | 14    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete |
-| **Total** | **40** | **20** | |
+| **Total** | **47** | **20** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >


### PR DESCRIPTION
## What

A code audit found that the headline bidirectional continuous co-evolution loop does NOT close in code — the components exist but the feedback edges are missing. This PR files the gaps honestly in the backlog and adds a maturity caveat.

## What was verified (all on main)

Each gap was verified against the source before filing:

1. **Daemon simulates, doesn't run pipeline** — `continuous_evolution_service.py:174` `_run_evolution_cycle` only reads `get_statistics()` and increments a counter (`'For now, we'll simulate...'`); never invokes `EvolutionPipeline`.
2. **Method-name bug** — `continuous_evolution_service.py:234` calls `training_manager.start_training()` which does not exist; the real method is `run_training_cycle` at `training_manager.py:195` → `AttributeError` if reached.
3. **Validation tests baseline, not fine-tuned model** — `model_validator.py:211,247,306,371,436` all use `OllamaProvider(model=self.baseline_model)`, ignoring the `model_path` argument.
4. **No real deployment** — `version_manager.register_version` copies weights + sets `current_version` in a JSON registry; no Modelfile, no `ollama create`, no symlink, nothing the serving layer reads.
5. **Generator never consults registry** — `version_manager.get_current_version()` has zero callers; the generator pipeline never uses the fine-tuning registry.
6. **No end-to-end test** — no test exercises collect → train → validate → deploy → regenerate.
7. **CLI stubs** — `evoseal start` (`cli/commands/start.py:39,57`) prints `"not yet implemented"`.

## Changes

**TODO.md:**
- Added 'Close the bidirectional co-evolution loop' subsection under P2 with 7 unchecked items, each citing file:line
- Tracking table updated (47 total, 20 done)

**EVOLUTION.md:**
- Added maturity caveat to Phase 3 status: modules are built but the loop is not yet operational co-evolution

## Verification

- `ruff format --check .` ✅
- `ruff check evoseal/ tests/` ✅
- `mkdocs build --strict` ✅ (1.85s)