### PR TITLE
fix: correct training method name in continuous evolution service

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,7 +104,7 @@
 > generator never consults the fine-tuning registry. These items close those gaps.
 
 - [ ] **Wire daemon to real EvolutionPipeline** — `continuous_evolution_service.py:174` `_run_evolution_cycle` only reads `get_statistics()` and simulates; must invoke `EvolutionPipeline` instead
-- [ ] **FIX: training call uses nonexistent method** — `continuous_evolution_service.py:234` calls `training_manager.start_training()` which does not exist; the real method is `run_training_cycle` at `training_manager.py:195` → `AttributeError` if reached
+- [x] **FIX: training call uses nonexistent method** _(done 2026-07-19, commit fix/training-method-name-bug)_ — `continuous_evolution_service.py:234` called `training_manager.start_training()` which did not exist; changed to `run_training_cycle()` and fixed `validation_passed` → `validation_results.passed`
 - [ ] **validate_model must serve the fine-tuned model, not baseline** — `model_validator.py:211,247,306,371,436` all use `OllamaProvider(model=self.baseline_model)`, ignoring the `model_path` argument; must load the fine-tuned model for validation
 - [ ] **Implement real model deployment** — `version_manager.register_version` only copies weights + sets `current_version` in a JSON registry; need actual deployment (Modelfile / `ollama create` / symlink) so the serving layer can load the model
 - [ ] **Generation must consult the fine-tuning registry** — `version_manager.get_current_version()` has zero callers; the generator (`integration/seal/*`, `evolution_pipeline.py`, `providers/local_models.py resolve_model`) must consult it to use the deployed fine-tuned model
@@ -211,9 +211,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 5     | 5    | All complete as of 2026-06-04 |
 | 🟠 P1    | 11    | 9    | Safety config path gap + Tier 2 deferred open |
-| 🟡 P2    | 17    | 0    | Co-evolution loop gaps (7 items) + existing P2 |
+| 🟡 P2    | 17    | 1    | Co-evolution loop gaps (7 items, 1 done) + existing P2 |
 | 🟢 P3    | 14    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete |
-| **Total** | **47** | **20** | |
+| **Total** | **47** | **21** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/evoseal/services/continuous_evolution_service.py
+++ b/evoseal/services/continuous_evolution_service.py
@@ -230,15 +230,15 @@ class ContinuousEvolutionService:
             if training_status.get("ready_for_training", False):
                 logger.info("🚀 Starting fine-tuning process")
 
-                # Start training (this will run in background)
-                training_result = await training_manager.start_training()
+                # Run training cycle
+                training_result = await training_manager.run_training_cycle()
 
                 if training_result.get("success", False):
                     logger.info("✅ Training cycle completed successfully")
                     self.service_stats["training_cycles_triggered"] += 1
 
                     # Check if this resulted in an improvement
-                    if training_result.get("validation_passed", False):
+                    if training_result.get("validation_results", {}).get("passed", False):
                         self.service_stats["successful_improvements"] += 1
                         logger.info("🎉 Model improvement achieved!")
                 else:

--- a/tests/unit/services/__init__.py
+++ b/tests/unit/services/__init__.py
@@ -1,0 +1,1 @@
+# tests/unit/services

--- a/tests/unit/services/test_continuous_evolution_service.py
+++ b/tests/unit/services/test_continuous_evolution_service.py
@@ -1,0 +1,71 @@
+"""Tests for ContinuousEvolutionService._trigger_training_cycle.
+
+Verifies the fix for the method-name bug: the service must call
+run_training_cycle() (not the nonexistent start_training()) and must
+check validation_results.passed (not validation_passed).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from evoseal.services.continuous_evolution_service import ContinuousEvolutionService
+
+
+def _make_service(tmp_path: Path) -> ContinuousEvolutionService:
+    """Build a ContinuousEvolutionService with mocked internals."""
+    with (
+        patch("evoseal.services.continuous_evolution_service.EvolutionDataCollector"),
+        patch("evoseal.services.continuous_evolution_service.BidirectionalEvolutionManager"),
+    ):
+        svc = ContinuousEvolutionService(data_dir=tmp_path / "svc")
+    return svc
+
+
+def test_trigger_training_calls_run_training_cycle(tmp_path):
+    """_trigger_training_cycle must call run_training_cycle (not start_training)."""
+    svc = _make_service(tmp_path)
+
+    training_mgr = AsyncMock()
+    training_mgr.get_training_status = AsyncMock(return_value={"ready_for_training": True})
+    training_mgr.run_training_cycle = AsyncMock(
+        return_value={"success": True, "validation_results": {"passed": True}}
+    )
+
+    svc.bidirectional_manager = MagicMock()
+    svc.bidirectional_manager.training_manager = training_mgr
+
+    asyncio.run(svc._trigger_training_cycle())
+
+    # (1) run_training_cycle was awaited — proving we no longer call start_training
+    training_mgr.run_training_cycle.assert_awaited_once()
+
+    # (2) training_cycles_triggered incremented
+    assert svc.service_stats["training_cycles_triggered"] == 1
+
+    # (3) successful_improvements incremented because validation passed
+    assert svc.service_stats["successful_improvements"] == 1
+
+
+def test_trigger_training_validation_failed(tmp_path):
+    """When validation_results.passed is False, successful_improvements stays 0."""
+    svc = _make_service(tmp_path)
+
+    training_mgr = AsyncMock()
+    training_mgr.get_training_status = AsyncMock(return_value={"ready_for_training": True})
+    training_mgr.run_training_cycle = AsyncMock(
+        return_value={"success": True, "validation_results": {"passed": False}}
+    )
+
+    svc.bidirectional_manager = MagicMock()
+    svc.bidirectional_manager.training_manager = training_mgr
+
+    asyncio.run(svc._trigger_training_cycle())
+
+    training_mgr.run_training_cycle.assert_awaited_once()
+    assert svc.service_stats["training_cycles_triggered"] == 1
+    assert svc.service_stats["successful_improvements"] == 0


### PR DESCRIPTION
## What

Fix co-evolution backlog item (b): `_trigger_training_cycle` called the nonexistent `start_training()` method and checked the wrong validation key.

## Bug (verified against code)

1. **Method name:** `continuous_evolution_service.py:234` called `training_manager.start_training()` — this method does not exist. The real method is `run_training_cycle()` at `training_manager.py:195`. Calling `start_training()` would raise AttributeError at runtime.

2. **Validation key:** The old code checked `training_result.get("validation_passed")`, but `run_training_cycle` returns `{"success": True, "validation_results": {...}}` where the pass/fail flag is `validation_results["passed"]` (set by `model_validator.py:136`). Changed to `training_result.get("validation_results", {}).get("passed", False)`.

## Fix (2 lines in `continuous_evolution_service.py`)

- Line 234: `start_training()` → `run_training_cycle()`
- Line 241: `validation_passed` → `validation_results.passed`

## Test

Added `tests/unit/services/test_continuous_evolution_service.py` with 2 cases:

- **Happy path:** `run_training_cycle` returns success with `validation_results.passed=True` → asserts `run_training_cycle` was awaited, `training_cycles_triggered == 1`, `successful_improvements == 1`
- **Validation failed:** same but `passed=False` → asserts `successful_improvements == 0`

Tests use mocked BidirectionalEvolutionManager (no GPU, no submodules needed).

## Pytest output

```
..                                                                       [100%]
2 passed, 4 warnings in 0.23s
```

## Verification

- ruff format --check: ✅ (294 files formatted)
- ruff check evoseal/ tests/: ✅ (all checks passed)
- pytest targeted test: ✅ (2 passed)

Closes TODO.md co-evolution loop item (b). Tracking table updated (P2 done 0->1, total 47->47/21).