### PR TITLE
docs: file flaky unmocked-network test as a backlog gap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -80,6 +80,7 @@
   - Verify the evolution loop can start (dependencies, permissions, Git state)
   - Flag budget/cost risks (no token limit configured, expensive model selected)
   - Surface risky configurations (e.g., immutable core protections disabled)
+- [ ] **Fix `test_authentication_handling` making a real unmocked network call** — `tests/version_control/test_advanced_operations.py:187` calls `repo.clone("https://github.com/private/nonexistent-repo.git")` against the real GitHub API instead of mocking it. Verified 2026-07-21: in an interactive TTY with a credential helper active, this hangs indefinitely on a live HTTPS username/password prompt instead of failing fast (blocked a real `git push`'s pre-push hook run this session); in batch mode it can also fail the `assert` when the returned error text doesn't match the expected substring list. Also leaves a stray `nonexistent-repo/` directory in the working tree on failure. Mock the clone failure instead of hitting the real network.
 
 ### Cost Management
 
@@ -211,10 +212,10 @@
 | Priority | Total | Done | Notes |
 |----------|-------|------|-------|
 | 🔴 P0    | 5     | 5    | All complete as of 2026-06-04 |
-| 🟠 P1    | 11    | 9    | Safety config path gap + Tier 2 deferred open |
+| 🟠 P1    | 12    | 9    | Safety config path gap + Tier 2 deferred + flaky auth test open |
 | 🟡 P2    | 17    | 3    | Co-evolution loop gaps (7 items, 3 done) + existing P2 |
 | 🟢 P3    | 14    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete |
-| **Total** | **47** | **23** | |
+| **Total** | **48** | **23** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >


### PR DESCRIPTION
Files `test_authentication_handling` (`tests/version_control/test_advanced_operations.py:187`) as a backlog gap: it makes a real HTTPS call to GitHub (`repo.clone("https://github.com/private/nonexistent-repo.git")`) instead of mocking it.

Verified today: in an interactive TTY with a credential helper active, this hangs indefinitely on a live username/password prompt instead of failing fast — it directly blocked a real `git push`'s pre-push hook run this session. In batch mode it can also fail its own assertion when the returned error text doesn't match the expected substring list, and it leaves a stray `nonexistent-repo/` directory in the working tree on failure.

Docs-only change, no code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a P1 action item to improve authentication error integration testing.
  * Updated project tracking totals and progress counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->