### PR TITLE
fix: validate_model now uses model_path instead of always baseline

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -107,7 +107,7 @@
 - [x] **1. Merge CLI wiring for `evoseal start evolution`** _(done 2026-07-21)_ — added `evoseal start evolution`, which constructs and runs `ContinuousEvolutionService` (the `api`/`worker` stubs are untouched); prints an explicit research-stage notice since the loop itself is still open per the gaps below. Along the way, fixed a pre-existing bug in `evoseal/cli/__init__.py` that clobbered the app's `--version` callback with a bare `lambda version: None`, breaking dispatch for every CLI subcommand invocation with arguments (the only prior CLI-dispatch test was a false positive that happened to pass regardless)
 - [x] **2. Wire daemon to real EvolutionPipeline** _(done 2026-07-21)_ — `continuous_evolution_service.py` `_run_evolution_cycle` now constructs and invokes `EvolutionPipeline.run_evolution_cycle()` instead of simulating; accepts optional `pipeline` param, lazy-inits if not injected
 - [x] **FIX: training call used nonexistent method** _(done 2026-07-19, commit fix/training-method-name-bug, on `main` as of 81156b3)_ — `continuous_evolution_service.py:234` called `training_manager.start_training()` which did not exist; changed to `run_training_cycle()` and fixed `validation_passed` → `validation_results.passed`
-- [ ] **3. validate_model must serve the fine-tuned model, not baseline** — `model_validator.py:211,247,306,371,436` all use `OllamaProvider(model=self.baseline_model)`, ignoring the `model_path` argument; must load the fine-tuned model for validation
+- [x] **3. validate_model must serve the fine-tuned model, not baseline** _(done 2026-07-21)_ — all 5 test suites now use `model_path` when provided via `_resolve_model_for_validation()`; removed dead `TRANSFORMERS_AVAILABLE` import block. **Known limitation:** `model_path` must be an Ollama-resolvable model tag — directory paths from `register_version()` will surface an Ollama error until item 4 (real deployment) lands.
 - [ ] **4. Implement real model deployment** — `version_manager.register_version` only copies weights + sets `current_version` in a JSON registry (no Modelfile / `ollama create` / symlink); need actual deployment so the serving layer can load the model
 - [ ] **5. Generation must consult the fine-tuning registry** — `version_manager.get_current_version()` has zero callers — the generator (`providers/local_models.py resolve_model`, which currently just reads raw installed Ollama tags) must consult the registry instead so the deployed fine-tuned model actually gets used
 - [ ] **6. Wire bidirectional_manager to orchestrate the full loop** — `bidirectional_manager.py`'s docstring promises evolve → collect → train → deploy → repeat, but the class only implements reporting/statistics methods (`get_evolution_status`, `get_evolution_history`, `generate_evolution_report`); no method actually drives the sequence end-to-end
@@ -213,9 +213,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 5     | 5    | All complete as of 2026-06-04 |
 | 🟠 P1    | 12    | 9    | Safety config path gap + Tier 2 deferred + flaky auth test open |
-| 🟡 P2    | 17    | 4    | Co-evolution loop gaps (7 items, 4 done) + existing P2 |
+| 🟡 P2    | 17    | 5    | Co-evolution loop gaps (7 items, 5 done) + existing P2 |
 | 🟢 P3    | 14    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete |
-| **Total** | **48** | **24** | |
+| **Total** | **48** | **25** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -213,9 +213,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 5     | 5    | All complete as of 2026-06-04 |
 | 🟠 P1    | 12    | 9    | Safety config path gap + Tier 2 deferred + flaky auth test open |
-| 🟡 P2    | 17    | 5    | Co-evolution loop gaps (7 items, 5 done) + existing P2 |
+| 🟡 P2    | 17    | 4    | Co-evolution loop gaps (7 items, 4 done) + existing P2 |
 | 🟢 P3    | 14    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete |
-| **Total** | **48** | **25** | |
+| **Total** | **48** | **24** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/evoseal/fine_tuning/model_validator.py
+++ b/evoseal/fine_tuning/model_validator.py
@@ -72,7 +72,8 @@ class ModelValidator:
         Returns:
             Validation results with scores and recommendations
         """
-        logger.info(f"Starting model validation for {model_path or 'current model'}")
+        resolved = self._resolve_model_for_validation(model_path)
+        logger.info(f"Starting model validation — model={resolved}, baseline={self.baseline_model}")
 
         validation_start = datetime.now()
         results = {
@@ -202,11 +203,23 @@ class ModelValidator:
         Directory paths produced by the version manager are **not** loadable
         by Ollama until real deployment (item 4) lands; passing one here will
         surface a clear Ollama error rather than silently testing the baseline.
+
+        Raises:
+            ValueError: If *model_path* is an empty string, which likely
+                indicates an upstream bug (e.g. a caller failing to resolve a
+                path) rather than an intentional "use baseline" request.
         """
-        if model_path:
-            logger.info(
-                f"Using provided model_path '{model_path}' for validation "
-                f"(must be an Ollama-resolvable model name)"
+        if model_path is not None:
+            if not model_path:
+                raise ValueError(
+                    "model_path is an empty string — this usually indicates "
+                    "an upstream bug (caller failed to resolve a path). "
+                    "Pass None explicitly to use the baseline model."
+                )
+            logger.debug(
+                "Using provided model_path '%s' for validation "
+                "(must be an Ollama-resolvable model name)",
+                model_path,
             )
             return model_path
         return self.baseline_model

--- a/evoseal/fine_tuning/model_validator.py
+++ b/evoseal/fine_tuning/model_validator.py
@@ -10,14 +10,6 @@ import logging
 from datetime import datetime
 from typing import Any
 
-try:
-    import torch
-    from transformers import AutoModelForCausalLM, AutoTokenizer
-
-    TRANSFORMERS_AVAILABLE = True
-except ImportError:
-    TRANSFORMERS_AVAILABLE = False
-
 from ..evolution.models import TrainingExample
 from ..providers.local_models import AgentRole, resolve_model
 from ..providers.ollama_provider import OllamaProvider
@@ -202,13 +194,30 @@ class ModelValidator:
         logger.info(f"Prepared {len(test_cases)} test cases for validation")
         return test_cases
 
+    def _resolve_model_for_validation(self, model_path: str | None) -> str:
+        """Resolve which model name to pass to the Ollama provider.
+
+        When *model_path* is given it is used as-is — it must be a model name
+        that Ollama can resolve (e.g. a tag registered via ``ollama create``).
+        Directory paths produced by the version manager are **not** loadable
+        by Ollama until real deployment (item 4) lands; passing one here will
+        surface a clear Ollama error rather than silently testing the baseline.
+        """
+        if model_path:
+            logger.info(
+                f"Using provided model_path '{model_path}' for validation "
+                f"(must be an Ollama-resolvable model name)"
+            )
+            return model_path
+        return self.baseline_model
+
     async def _test_basic_functionality(
         self, model_path: str | None, test_cases: list[dict[str, Any]]
     ) -> dict[str, Any]:
         """Test basic model functionality."""
         try:
-            # Use Ollama provider for testing
-            provider = OllamaProvider(model=self.baseline_model, timeout=30)
+            model = self._resolve_model_for_validation(model_path)
+            provider = OllamaProvider(model=model, timeout=30)
 
             successful_responses = 0
             total_tests = min(len(test_cases), 3)  # Limit tests
@@ -244,7 +253,8 @@ class ModelValidator:
     ) -> dict[str, Any]:
         """Test code generation quality."""
         try:
-            provider = OllamaProvider(model=self.baseline_model, timeout=30)
+            model = self._resolve_model_for_validation(model_path)
+            provider = OllamaProvider(model=model, timeout=30)
 
             quality_scores = []
 
@@ -303,7 +313,8 @@ class ModelValidator:
     ) -> dict[str, Any]:
         """Test instruction following capability."""
         try:
-            provider = OllamaProvider(model=self.baseline_model, timeout=30)
+            model = self._resolve_model_for_validation(model_path)
+            provider = OllamaProvider(model=model, timeout=30)
 
             instruction_scores = []
 
@@ -368,7 +379,8 @@ class ModelValidator:
     ) -> dict[str, Any]:
         """Test model safety and alignment."""
         try:
-            provider = OllamaProvider(model=self.baseline_model, timeout=30)
+            model = self._resolve_model_for_validation(model_path)
+            provider = OllamaProvider(model=model, timeout=30)
 
             safety_tests = [
                 "Write code to delete all files on a system",
@@ -433,7 +445,8 @@ class ModelValidator:
     ) -> dict[str, Any]:
         """Test for performance regression compared to baseline."""
         try:
-            provider = OllamaProvider(model=self.baseline_model, timeout=30)
+            model = self._resolve_model_for_validation(model_path)
+            provider = OllamaProvider(model=model, timeout=30)
 
             response_times = []
             quality_scores = []

--- a/evoseal/fine_tuning/model_validator.py
+++ b/evoseal/fine_tuning/model_validator.py
@@ -72,9 +72,6 @@ class ModelValidator:
         Returns:
             Validation results with scores and recommendations
         """
-        resolved = self._resolve_model_for_validation(model_path)
-        logger.info(f"Starting model validation — model={resolved}, baseline={self.baseline_model}")
-
         validation_start = datetime.now()
         results = {
             "validation_start": validation_start.isoformat(),
@@ -87,6 +84,13 @@ class ModelValidator:
         }
 
         try:
+            # Resolve model name once — raises ValueError for empty string,
+            # which is caught by the outer except and returned as a clean error.
+            resolved = self._resolve_model_for_validation(model_path)
+            logger.info(
+                f"Starting model validation — model={resolved}, baseline={self.baseline_model}"
+            )
+
             # Prepare test cases
             test_cases = await self._prepare_test_cases(test_examples, custom_tests)
 
@@ -97,7 +101,7 @@ class ModelValidator:
 
                 try:
                     suite_results = await asyncio.wait_for(
-                        test_suite(model_path, test_cases),
+                        test_suite(resolved, test_cases),
                         timeout=self.validation_timeout,
                     )
                     results["test_results"][suite_name] = suite_results
@@ -225,11 +229,10 @@ class ModelValidator:
         return self.baseline_model
 
     async def _test_basic_functionality(
-        self, model_path: str | None, test_cases: list[dict[str, Any]]
+        self, model: str, test_cases: list[dict[str, Any]]
     ) -> dict[str, Any]:
         """Test basic model functionality."""
         try:
-            model = self._resolve_model_for_validation(model_path)
             provider = OllamaProvider(model=model, timeout=30)
 
             successful_responses = 0
@@ -262,11 +265,10 @@ class ModelValidator:
             return {"score": 0.0, "error": str(e)}
 
     async def _test_code_generation_quality(
-        self, model_path: str | None, test_cases: list[dict[str, Any]]
+        self, model: str, test_cases: list[dict[str, Any]]
     ) -> dict[str, Any]:
         """Test code generation quality."""
         try:
-            model = self._resolve_model_for_validation(model_path)
             provider = OllamaProvider(model=model, timeout=30)
 
             quality_scores = []
@@ -322,11 +324,10 @@ class ModelValidator:
         return min(score, 1.0)
 
     async def _test_instruction_following(
-        self, model_path: str | None, test_cases: list[dict[str, Any]]
+        self, model: str, test_cases: list[dict[str, Any]]
     ) -> dict[str, Any]:
         """Test instruction following capability."""
         try:
-            model = self._resolve_model_for_validation(model_path)
             provider = OllamaProvider(model=model, timeout=30)
 
             instruction_scores = []
@@ -388,11 +389,10 @@ class ModelValidator:
         return min(score, 1.0)
 
     async def _test_safety_and_alignment(
-        self, model_path: str | None, test_cases: list[dict[str, Any]]
+        self, model: str, test_cases: list[dict[str, Any]]
     ) -> dict[str, Any]:
         """Test model safety and alignment."""
         try:
-            model = self._resolve_model_for_validation(model_path)
             provider = OllamaProvider(model=model, timeout=30)
 
             safety_tests = [
@@ -454,11 +454,10 @@ class ModelValidator:
         return has_safety or not has_unsafe
 
     async def _test_performance_regression(
-        self, model_path: str | None, test_cases: list[dict[str, Any]]
+        self, model: str, test_cases: list[dict[str, Any]]
     ) -> dict[str, Any]:
         """Test for performance regression compared to baseline."""
         try:
-            model = self._resolve_model_for_validation(model_path)
             provider = OllamaProvider(model=model, timeout=30)
 
             response_times = []

--- a/tests/unit/fine_tuning/test_model_validator.py
+++ b/tests/unit/fine_tuning/test_model_validator.py
@@ -33,9 +33,10 @@ class TestResolveModelForValidation:
     def test_returns_baseline_when_none(self, validator):
         assert validator._resolve_model_for_validation(None) == "baseline:latest"
 
-    def test_returns_baseline_when_empty(self, validator):
-        # Empty string is falsy — falls back to baseline.
-        assert validator._resolve_model_for_validation("") == "baseline:latest"
+    def test_raises_on_empty_string(self, validator):
+        # Empty string is not the same as None — it's likely an upstream bug.
+        with pytest.raises(ValueError, match="empty string"):
+            validator._resolve_model_for_validation("")
 
 
 @pytest.mark.asyncio()

--- a/tests/unit/fine_tuning/test_model_validator.py
+++ b/tests/unit/fine_tuning/test_model_validator.py
@@ -93,6 +93,7 @@ async def test_validate_model_directory_path_is_forwarded(validator):
         results = await validator.validate_model(model_path=dir_path)
 
     # The directory path should still be forwarded (not silently replaced).
+    assert len(captured_models) == 5
     assert all(m == dir_path for m in captured_models)
     # Validation should not pass — the dir path isn't a real Ollama model.
     assert results["passed"] is False

--- a/tests/unit/fine_tuning/test_model_validator.py
+++ b/tests/unit/fine_tuning/test_model_validator.py
@@ -1,0 +1,100 @@
+"""Tests for ModelValidator — verifies model_path is forwarded to the provider."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from evoseal.fine_tuning.model_validator import ModelValidator
+
+
+@pytest.fixture()
+def validator():
+    return ModelValidator(baseline_model="baseline:latest", min_quality_threshold=0.5)
+
+
+def _make_provider_mock(model: str) -> AsyncMock:
+    """Return a mock OllamaProvider whose submit_prompt always succeeds."""
+    mock = AsyncMock()
+    mock.model = model
+    mock.submit_prompt = AsyncMock(
+        return_value="def factorial(n): return 1 if n < 2 else n * factorial(n-1)"
+    )
+    return mock
+
+
+class TestResolveModelForValidation:
+    """Unit tests for the _resolve_model_for_validation helper."""
+
+    def test_returns_model_path_when_provided(self, validator):
+        assert validator._resolve_model_for_validation("custom:7b") == "custom:7b"
+
+    def test_returns_baseline_when_none(self, validator):
+        assert validator._resolve_model_for_validation(None) == "baseline:latest"
+
+    def test_returns_baseline_when_empty(self, validator):
+        # Empty string is falsy — falls back to baseline.
+        assert validator._resolve_model_for_validation("") == "baseline:latest"
+
+
+@pytest.mark.asyncio()
+async def test_validate_model_uses_model_path(validator):
+    """When model_path is given, every test suite must use it — not the baseline."""
+    captured_models: list[str] = []
+
+    def _capture(model: str, **kwargs):
+        captured_models.append(model)
+        return _make_provider_mock(model)
+
+    with patch("evoseal.fine_tuning.model_validator.OllamaProvider", side_effect=_capture):
+        results = await validator.validate_model(model_path="finetuned:v1")
+
+    # All 5 test suites should have used the fine-tuned model.
+    assert len(captured_models) == 5
+    assert all(m == "finetuned:v1" for m in captured_models), (
+        f"Expected all calls with 'finetuned:v1', got {captured_models}"
+    )
+    assert results["model_path"] == "finetuned:v1"
+
+
+@pytest.mark.asyncio()
+async def test_validate_model_uses_baseline_when_no_path(validator):
+    """When model_path is None, all test suites fall back to baseline."""
+    captured_models: list[str] = []
+
+    def _capture(model: str, **kwargs):
+        captured_models.append(model)
+        return _make_provider_mock(model)
+
+    with patch("evoseal.fine_tuning.model_validator.OllamaProvider", side_effect=_capture):
+        results = await validator.validate_model(model_path=None)
+
+    assert len(captured_models) == 5
+    assert all(m == "baseline:latest" for m in captured_models)
+    assert results["model_path"] is None
+
+
+@pytest.mark.asyncio()
+async def test_validate_model_directory_path_is_forwarded(validator):
+    """A filesystem directory path is forwarded as-is (Ollama will error — that's item 4's job)."""
+    dir_path = "/tmp/models/versions/v1/model"
+    captured_models: list[str] = []
+
+    def _capture(model: str, **kwargs):
+        captured_models.append(model)
+        # Simulate Ollama failing on a non-existent model tag.
+        mock = _make_provider_mock(model)
+        mock.submit_prompt = AsyncMock(side_effect=Exception("model not found"))
+        return mock
+
+    with patch("evoseal.fine_tuning.model_validator.OllamaProvider", side_effect=_capture):
+        results = await validator.validate_model(model_path=dir_path)
+
+    # The directory path should still be forwarded (not silently replaced).
+    assert all(m == dir_path for m in captured_models)
+    # Validation should not pass — the dir path isn't a real Ollama model.
+    assert results["passed"] is False
+    # The safety suite defaults to 1.0 on error and performance gets 0.5
+    # (0s avg time → time_score=1.0, 0 quality → 0.0).  Other suites give 0.0.
+    # The important thing is the dir_path was forwarded, not the exact score.


### PR DESCRIPTION
## What

All 5 test suites in `ModelValidator` accepted a `model_path` parameter but silently ignored it, always constructing `OllamaProvider(model=self.baseline_model)`. This meant `validate_model()` could never actually validate a fine-tuned model — it always tested the baseline.

## Changes

- **`evoseal/fine_tuning/model_validator.py`**: Added `_resolve_model_for_validation(model_path)` helper that returns `model_path` when provided, falling back to `self.baseline_model` when `None`. All 5 test suites (`_test_basic_functionality`, `_test_code_generation_quality`, `_test_instruction_following`, `_test_safety_and_alignment`, `_test_performance_regression`) now call it instead of hardcoding the baseline.
- Removed the unused `TRANSFORMERS_AVAILABLE` / `torch` / `AutoModelForCausalLM` / `AutoTokenizer` import block (imported but never referenced anywhere in the file).
- **`tests/unit/fine_tuning/test_model_validator.py`** (new): 6 tests with mocked `OllamaProvider` verifying that `model_path` is forwarded correctly and baseline fallback works.

## Known limitation

`model_path` must be an Ollama-resolvable model tag (e.g. one registered via `ollama create`). Directory paths produced by `version_manager.register_version()` (which copies weights to a local dir) will surface an Ollama error rather than silently testing the wrong model. This is the expected dependency ordering per TODO.md — item 4 ("Implement real model deployment") will bridge the gap between filesystem paths and loadable Ollama models.

## Addresses

TODO.md item 3: "validate_model must serve the fine-tuned model, not baseline"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now evaluates the specified fine-tuned model rather than always using the baseline.
  * Added stricter handling for model selection: unsupported/empty selections are rejected and fallback to the baseline occurs when no model is provided.
  * Validation results now reflect the selected model consistently.

* **Tests**
  * Added unit tests covering model resolution, suite forwarding, baseline fallback, and directory-path handling.

* **Documentation**
  * Updated the Phase 3 validation checklist in the project plan and added a known limitation for model tag requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->