### PR TITLE
fix: mock network call in test_authentication_handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -80,7 +80,7 @@
   - Verify the evolution loop can start (dependencies, permissions, Git state)
   - Flag budget/cost risks (no token limit configured, expensive model selected)
   - Surface risky configurations (e.g., immutable core protections disabled)
-- [ ] **Fix `test_authentication_handling` making a real unmocked network call** — `tests/version_control/test_advanced_operations.py:187` calls `repo.clone("https://github.com/private/nonexistent-repo.git")` against the real GitHub API instead of mocking it. Verified 2026-07-21: in an interactive TTY with a credential helper active, this hangs indefinitely on a live HTTPS username/password prompt instead of failing fast (blocked a real `git push`'s pre-push hook run this session); in batch mode it can also fail the `assert` when the returned error text doesn't match the expected substring list. Also leaves a stray `nonexistent-repo/` directory in the working tree on failure. Mock the clone failure instead of hitting the real network.
+- [x] **Fix `test_authentication_handling` making a real unmocked network call** _(done 2026-07-22)_ — `tests/version_control/test_advanced_operations.py:187` now mocks `CmdGit._run_git_command` to simulate an authentication failure instead of calling the real GitHub API. Eliminates the hang in interactive TTYs (credential prompt) and stray directory on failure.
 
 ### Cost Management
 
@@ -212,10 +212,10 @@
 | Priority | Total | Done | Notes |
 |----------|-------|------|-------|
 | 🔴 P0    | 5     | 5    | All complete as of 2026-06-04 |
-| 🟠 P1    | 12    | 9    | Safety config path gap + Tier 2 deferred + flaky auth test open |
+| 🟠 P1    | 12    | 10   | All safety hardening + integration items done; Tier 2 deferred
 | 🟡 P2    | 17    | 4    | Co-evolution loop gaps (7 items, 4 done) + existing P2 |
 | 🟢 P3    | 14    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete |
-| **Total** | **48** | **24** | |
+| **Total** | **48** | **25** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -212,7 +212,7 @@
 | Priority | Total | Done | Notes |
 |----------|-------|------|-------|
 | 🔴 P0    | 5     | 5    | All complete as of 2026-06-04 |
-| 🟠 P1    | 12    | 10   | All safety hardening + integration items done; Tier 2 deferred
+| 🟠 P1    | 12    | 10   | All safety hardening + integration items done; Tier 2 deferred |
 | 🟡 P2    | 17    | 4    | Co-evolution loop gaps (7 items, 4 done) + existing P2 |
 | 🟢 P3    | 14    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete |
 | **Total** | **48** | **25** | |

--- a/tests/version_control/test_advanced_operations.py
+++ b/tests/version_control/test_advanced_operations.py
@@ -1,6 +1,7 @@
 """Unit tests for advanced Git operations."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -186,12 +187,23 @@ def test_repository_structure(git_repo_with_commit: CmdGit):
 
 def test_authentication_handling(temp_dir: Path):
     """Test authentication error handling."""
-    # This test verifies that authentication errors are properly raised
-    # We'll use a non-existent private repo that requires authentication
+    # Mock the git command to avoid making real network calls.
+    # Previously this test cloned a nonexistent private repo against the
+    # real GitHub API, which hangs in interactive TTYs (credential prompt)
+    # and can leave stray directories on failure.
     repo = CmdGit(repo_path=temp_dir / "test_repo")
 
-    with pytest.raises(GitError) as excinfo:
-        repo.clone("https://github.com/private/nonexistent-repo.git")
+    with patch.object(
+        CmdGit,
+        "_run_git_command",
+        return_value=(
+            False,
+            "",
+            "Permission denied (publickey). fatal: Could not read from remote repository.",
+        ),
+    ):
+        with pytest.raises(GitError) as excinfo:
+            repo.clone("https://github.com/private/nonexistent-repo.git")
 
     # The exact error message might vary, but it should indicate an authentication failure
     assert any(


### PR DESCRIPTION
## What

Mocks `CmdGit._run_git_command` in `test_authentication_handling` to simulate an authentication failure instead of making a real `git clone` call to GitHub.

## Why

The test previously called `repo.clone("https://github.com/private/nonexistent-repo.git")` against the real GitHub API. This caused:

- **Hangs in interactive TTYs** — a credential prompt blocks indefinitely when a credential helper is active
- **Stray directories on failure** — a `nonexistent-repo/` directory is left in the working tree
- **Flaky assertions** — error text varies by environment, causing intermittent failures

## How

- Added `from unittest.mock import patch`
- Wrapped the `clone` call with `patch.object(CmdGit, "_run_git_command", return_value=(False, stderr, ...))` to simulate the auth failure
- All original assertions on `GitError` message content are preserved

## Verification

```
$ ruff format --check . && ruff check evoseal/ tests/
295 files already formatted
All checks passed!

$ python -m pytest tests/version_control/test_advanced_operations.py -q
7 passed, 26 warnings in 12.23s
```

Addresses TODO.md item: *Fix `test_authentication_handling` making a real unmocked network call*