### PR TITLE
feat: implement real model deployment to Ollama

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -170,7 +170,7 @@
 - [x] **2. Wire daemon to real EvolutionPipeline** _(done 2026-07-21)_ — `continuous_evolution_service.py` `_run_evolution_cycle` now constructs and invokes `EvolutionPipeline.run_evolution_cycle()` instead of simulating; accepts optional `pipeline` param, lazy-inits if not injected
 - [x] **FIX: training call used nonexistent method** _(done 2026-07-19, commit fix/training-method-name-bug, on `main` as of 81156b3)_ — `continuous_evolution_service.py:234` called `training_manager.start_training()` which did not exist; changed to `run_training_cycle()` and fixed `validation_passed` → `validation_results.passed`
 - [x] **3. validate_model must serve the fine-tuned model, not baseline** _(done 2026-07-21)_ — all 5 test suites now use `model_path` when provided via `_resolve_model_for_validation()`; removed dead `TRANSFORMERS_AVAILABLE` import block. **Known limitation:** `model_path` must be an Ollama-resolvable model tag — directory paths from `register_version()` will surface an Ollama error until item 4 (real deployment) lands.
-- [ ] **4. Implement real model deployment** — `version_manager.register_version` only copies weights + sets `current_version` in a JSON registry (no Modelfile / `ollama create` / symlink); need actual deployment so the serving layer can load the model
+- [x] **4. Implement real model deployment** — `version_manager.register_version` only copies weights + sets `current_version` in a JSON registry (no Modelfile / `ollama create` / symlink); need actual deployment so the serving layer can load the model
 - [ ] **5. Generation must consult the fine-tuning registry** — `version_manager.get_current_version()` has zero callers — the generator (`providers/local_models.py resolve_model`, which currently just reads raw installed Ollama tags) must consult the registry instead so the deployed fine-tuned model actually gets used
 - [ ] **6. Wire bidirectional_manager to orchestrate the full loop** — `bidirectional_manager.py`'s docstring promises evolve → collect → train → deploy → repeat, but the class only implements reporting/statistics methods (`get_evolution_status`, `get_evolution_history`, `generate_evolution_report`); no method actually drives the sequence end-to-end
 - [ ] **Add end-to-end bidirectional loop test** — exercise the full cycle: collect → train → validate → deploy → regenerate; no such test exists today (write once steps 1–6 land)
@@ -303,9 +303,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 10   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
-| 🟡 P2    | 29    | 4    | Co-evolution loop gaps (7 items, 4 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
+| 🟡 P2    | 29    | 5    | Co-evolution loop gaps (7 items, 5 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
 | 🟢 P3    | 24    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
-| **Total** | **88** | **31** | |
+| **Total** | **88** | **32** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -5,6 +5,7 @@ This module handles versioning, rollback, and deployment of fine-tuned models
 in the bidirectional evolution system.
 """
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -135,7 +136,7 @@ class ModelVersionManager:
                 # Copy model files
                 try:
                     shutil.copytree(model_path, version_dir / "model", dirs_exist_ok=True)
-                    version_info["model_path"] = str(version_dir / "model")
+                    version_info["model_path"] = str((version_dir / "model").resolve())
                     version_info["status"] = "stored"
                 except Exception as e:
                     logger.warning(f"Could not copy model files: {e}")
@@ -264,7 +265,6 @@ class ModelVersionManager:
         self,
         version_id: str,
         ollama_model_name: str | None = None,
-        base_url: str = "http://localhost:11434",
     ) -> dict[str, Any]:
         """
         Deploy a registered model version to Ollama.
@@ -275,7 +275,6 @@ class ModelVersionManager:
         Args:
             version_id: Version ID to deploy
             ollama_model_name: Ollama model name (default: version_name)
-            base_url: Ollama API base URL
 
         Returns:
             Deployment result dict with 'ollama_model' on success or 'error'
@@ -301,8 +300,10 @@ class ModelVersionManager:
         except OSError as e:
             return {"error": f"Could not write Modelfile: {e}"}
 
-        # Run ollama create
-        deploy_error = self._deploy_to_ollama(ollama_model_name, modelfile_path, base_url)
+        # Run ollama create (in a thread to avoid blocking the event loop)
+        deploy_error = await asyncio.to_thread(
+            self._deploy_to_ollama, ollama_model_name, modelfile_path
+        )
         if deploy_error:
             # Update registry with failure
             version_info["deployment_status"] = "failed"
@@ -336,9 +337,12 @@ class ModelVersionManager:
         """Generate a Modelfile for the given model directory.
 
         Handles two common formats:
-        - GGUF files (``*.gguf``): direct ``FROM`` reference
+        - GGUF files (``*.gguf``): direct ``FROM`` reference (largest file
+          when multiple quantizations exist)
         - HuggingFace safetensors / adapter directories: ``FROM`` the directory
           (Ollama >= 0.4 supports ``FROM <dir>`` for safetensors models)
+        - LoRA/PEFT adapter directories: ``FROM <base>`` + ``ADAPTER <path>``
+          when an adapter config is detected
 
         Args:
             model_path: Path to the model files
@@ -351,20 +355,41 @@ class ModelVersionManager:
         # Check for GGUF files first
         gguf_files = list(p.glob("*.gguf"))
         if gguf_files:
-            # Use the first GGUF found (usually there's only one)
-            return f"FROM {gguf_files[0]}\n"
+            # Pick the largest GGUF deterministically (avoids arbitrary
+            # filesystem order when multiple quantizations exist).
+            selected = max(gguf_files, key=lambda f: f.stat().st_size)
+            return f"FROM {selected}\n"
+
+        # Detect LoRA/PEFT adapter directory — these need ADAPTER syntax,
+        # not a bare FROM.  adapter_config.json is the canonical marker.
+        if (p / "adapter_config.json").exists():
+            try:
+                import json as _json
+
+                with open(p / "adapter_config.json") as f:
+                    cfg = _json.load(f)
+                base_model = cfg.get("base_model_name_or_path", "")
+                if base_model:
+                    return f"FROM {base_model}\nADAPTER {p}\n"
+            except Exception:
+                pass
+            # If we can't read the config, fall through to FROM <dir> and
+            # let ollama produce a clear error rather than silently breaking.
+            logger.warning(
+                f"adapter_config.json found at {p} but could not read base model"
+                " — falling back to FROM <dir> which may not work"
+            )
 
         # HuggingFace directory — point FROM at the directory itself
         return f"FROM {p}\n"
 
     @staticmethod
-    def _deploy_to_ollama(model_name: str, modelfile_path: Path, base_url: str) -> str | None:
+    def _deploy_to_ollama(model_name: str, modelfile_path: Path) -> str | None:
         """Run ``ollama create`` to register a model with Ollama.
 
         Args:
             model_name: Name for the new Ollama model
             modelfile_path: Path to the Modelfile
-            base_url: Ollama base URL (used for logging only; ollama CLI uses the daemon)
 
         Returns:
             None on success, error message string on failure.

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -167,21 +167,19 @@ class ModelVersionManager:
                     logger.warning(
                         f"Model registered but deployment failed: {deploy_result['error']}"
                     )
-                    version_info["deployment_error"] = deploy_result["error"]
+                # Re-fetch from registry so the returned dict carries the
+                # deployment fields (deployment_status, ollama_model_name,
+                # deployed_at / deployment_error) written by deploy_version,
+                # regardless of whether get_version_info returns by reference
+                # or by copy.
+                version_info = self.get_version_info(version_id) or version_info
             elif deploy and not version_info.get("model_path"):
+                version_info["deployment_status"] = "failed"
                 version_info["deployment_error"] = "deploy requested but no model_path available"
                 logger.warning(
                     f"Version {version_id}: deploy=True but no model_path; skipping deployment"
                 )
                 self._save_registry()
-                # NOTE: deploy_version mutates the same dict object that
-                # get_version_info returns (it iterates self.registry["versions"]
-                # and returns the matching entry by reference).  The deployment
-                # fields (deployment_status, ollama_model_name, deployed_at) set
-                # inside deploy_version are therefore visible here.  If
-                # get_version_info is ever changed to return a *copy*, this
-                # return value would silently omit those fields — callers
-                # should then re-fetch via get_version_info after deploy.
 
             return version_info
 

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import logging
 import shutil
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -79,6 +80,9 @@ class ModelVersionManager:
         validation_results: dict[str, Any] | None = None,
         data_prep_results: dict[str, Any] | None = None,
         version_name: str | None = None,
+        *,
+        deploy: bool = False,
+        ollama_model_name: str | None = None,
     ) -> dict[str, Any]:
         """
         Register a new model version.
@@ -151,6 +155,18 @@ class ModelVersionManager:
             self._save_registry()
 
             logger.info(f"Registered model version {version_id} ({version_name})")
+
+            # Deploy to Ollama if requested and model files are available
+            if deploy and version_info.get("model_path"):
+                deploy_result = await self.deploy_version(
+                    version_id, ollama_model_name=ollama_model_name
+                )
+                if "error" in deploy_result:
+                    logger.warning(
+                        f"Model registered but deployment failed: {deploy_result['error']}"
+                    )
+                    version_info["deployment_error"] = deploy_result["error"]
+
             return version_info
 
         except Exception as e:
@@ -244,6 +260,135 @@ class ModelVersionManager:
             return self.get_version_info(current_id)
         return None
 
+    async def deploy_version(
+        self,
+        version_id: str,
+        ollama_model_name: str | None = None,
+        base_url: str = "http://localhost:11434",
+    ) -> dict[str, Any]:
+        """
+        Deploy a registered model version to Ollama.
+
+        Creates a Modelfile and runs ``ollama create`` so the serving layer
+        (OllamaProvider) can load the fine-tuned model.
+
+        Args:
+            version_id: Version ID to deploy
+            ollama_model_name: Ollama model name (default: version_name)
+            base_url: Ollama API base URL
+
+        Returns:
+            Deployment result dict with 'ollama_model' on success or 'error'
+        """
+        version_info = self.get_version_info(version_id)
+        if not version_info:
+            return {"error": f"Version {version_id} not found"}
+
+        model_path = version_info.get("model_path")
+        if not model_path or not Path(model_path).exists():
+            return {"error": f"Model files not found at {model_path}"}
+
+        # Determine Ollama model name
+        if not ollama_model_name:
+            ollama_model_name = version_info.get("version_name", version_id)
+
+        # Create Modelfile
+        modelfile_content = self._create_modelfile(model_path)
+        modelfile_path = self.versions_dir / version_id / "Modelfile"
+        try:
+            modelfile_path.parent.mkdir(parents=True, exist_ok=True)
+            modelfile_path.write_text(modelfile_content)
+        except OSError as e:
+            return {"error": f"Could not write Modelfile: {e}"}
+
+        # Run ollama create
+        deploy_error = self._deploy_to_ollama(ollama_model_name, modelfile_path, base_url)
+        if deploy_error:
+            # Update registry with failure
+            version_info["deployment_status"] = "failed"
+            version_info["deployment_error"] = deploy_error
+            self._save_registry()
+            return {"error": deploy_error}
+
+        # Update registry with success
+        version_info["deployment_status"] = "deployed"
+        version_info["ollama_model_name"] = ollama_model_name
+        version_info["deployed_at"] = datetime.now().isoformat()
+        self._save_registry()
+
+        # Clear the installed-model cache so resolve_model picks up the new model
+        try:
+            from evoseal.providers.local_models import clear_model_cache
+
+            clear_model_cache()
+        except ImportError:
+            pass
+
+        logger.info(f"Deployed version {version_id} as Ollama model '{ollama_model_name}'")
+        return {
+            "ollama_model": ollama_model_name,
+            "version_id": version_id,
+            "modelfile": str(modelfile_path),
+        }
+
+    @staticmethod
+    def _create_modelfile(model_path: str) -> str:
+        """Generate a Modelfile for the given model directory.
+
+        Handles two common formats:
+        - GGUF files (``*.gguf``): direct ``FROM`` reference
+        - HuggingFace safetensors / adapter directories: ``FROM`` the directory
+          (Ollama >= 0.4 supports ``FROM <dir>`` for safetensors models)
+
+        Args:
+            model_path: Path to the model files
+
+        Returns:
+            Modelfile content string
+        """
+        p = Path(model_path)
+
+        # Check for GGUF files first
+        gguf_files = list(p.glob("*.gguf"))
+        if gguf_files:
+            # Use the first GGUF found (usually there's only one)
+            return f"FROM {gguf_files[0]}\n"
+
+        # HuggingFace directory — point FROM at the directory itself
+        return f"FROM {p}\n"
+
+    @staticmethod
+    def _deploy_to_ollama(model_name: str, modelfile_path: Path, base_url: str) -> str | None:
+        """Run ``ollama create`` to register a model with Ollama.
+
+        Args:
+            model_name: Name for the new Ollama model
+            modelfile_path: Path to the Modelfile
+            base_url: Ollama base URL (used for logging only; ollama CLI uses the daemon)
+
+        Returns:
+            None on success, error message string on failure.
+        """
+        try:
+            result = subprocess.run(
+                ["ollama", "create", model_name, "-f", str(modelfile_path)],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            if result.returncode != 0:
+                error = result.stderr.strip() or result.stdout.strip() or "unknown error"
+                logger.error(f"ollama create failed: {error}")
+                return error
+            logger.info(f"ollama create succeeded for '{model_name}'")
+            return None
+        except FileNotFoundError:
+            return "ollama CLI not found on PATH"
+        except subprocess.TimeoutExpired:
+            return "ollama create timed out after 300s"
+        except OSError as e:
+            return f"Could not run ollama create: {e}"
+
     def get_version_statistics(self) -> dict[str, Any]:
         """Get statistics about model versions."""
         versions = self.registry["versions"]
@@ -267,9 +412,16 @@ class ModelVersionManager:
             if score is not None:
                 validation_scores.append(score)
 
+        # Deployment status distribution
+        deploy_counts = {}
+        for version in versions:
+            deploy_status = version.get("deployment_status", "pending")
+            deploy_counts[deploy_status] = deploy_counts.get(deploy_status, 0) + 1
+
         stats = {
             "total_versions": total_versions,
             "status_distribution": status_counts,
+            "deployment_distribution": deploy_counts,
             "current_version": self.registry.get("current_version"),
             "registry_created": self.registry.get("created"),
             "registry_updated": self.registry.get("updated"),

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -168,6 +168,11 @@ class ModelVersionManager:
                         f"Model registered but deployment failed: {deploy_result['error']}"
                     )
                     version_info["deployment_error"] = deploy_result["error"]
+            elif deploy and not version_info.get("model_path"):
+                version_info["deployment_error"] = "deploy requested but no model_path available"
+                logger.warning(
+                    f"Version {version_id}: deploy=True but no model_path; skipping deployment"
+                )
                 # NOTE: deploy_version mutates the same dict object that
                 # get_version_info returns (it iterates self.registry["versions"]
                 # and returns the matching entry by reference).  The deployment
@@ -308,16 +313,38 @@ class ModelVersionManager:
             logger.info(f"Sanitized Ollama model name: {ollama_model_name!r} -> {sanitized!r}")
         ollama_model_name = sanitized
 
+        # Guard against ollama_model_name collision with another version.
+        # ollama create silently overwrites the tag, but the superseded
+        # version's registry entry would still claim "deployed" under the
+        # same name — making two entries look live for one tag.
+        for other in self.registry["versions"]:
+            if (
+                other["version_id"] != version_id
+                and other.get("ollama_model_name") == ollama_model_name
+            ):
+                other["deployment_status"] = "superseded"
+                logger.info(
+                    f"Marked version {other['version_id']} as superseded: "
+                    f"Ollama model name '{ollama_model_name}' is being reused "
+                    f"by version {version_id}"
+                )
+
         # Create Modelfile
         try:
             modelfile_content = self._create_modelfile(model_path)
         except ValueError as e:
+            version_info["deployment_status"] = "failed"
+            version_info["deployment_error"] = str(e)
+            self._save_registry()
             return {"error": str(e)}
         modelfile_path = self.versions_dir / version_id / "Modelfile"
         try:
             modelfile_path.parent.mkdir(parents=True, exist_ok=True)
             modelfile_path.write_text(modelfile_content)
         except OSError as e:
+            version_info["deployment_status"] = "failed"
+            version_info["deployment_error"] = f"Could not write Modelfile: {e}"
+            self._save_registry()
             return {"error": f"Could not write Modelfile: {e}"}
 
         # Run ollama create (in a thread to avoid blocking the event loop)
@@ -412,8 +439,8 @@ class ModelVersionManager:
                 base_model = cfg.get("base_model_name_or_path", "")
                 if base_model:
                     return f"FROM {base_model}\nADAPTER {p}\n"
-            except Exception:
-                pass
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f"adapter_config.json found at {p} but could not be parsed: {e}")
             # If we can't read the config, fall through to FROM <dir> and
             # let ollama produce a clear error rather than silently breaking.
             logger.warning(

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -9,6 +9,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import re
 import shutil
 import subprocess
 from datetime import datetime
@@ -167,6 +168,14 @@ class ModelVersionManager:
                         f"Model registered but deployment failed: {deploy_result['error']}"
                     )
                     version_info["deployment_error"] = deploy_result["error"]
+                # NOTE: deploy_version mutates the same dict object that
+                # get_version_info returns (it iterates self.registry["versions"]
+                # and returns the matching entry by reference).  The deployment
+                # fields (deployment_status, ollama_model_name, deployed_at) set
+                # inside deploy_version are therefore visible here.  If
+                # get_version_info is ever changed to return a *copy*, this
+                # return value would silently omit those fields — callers
+                # should then re-fetch via get_version_info after deploy.
 
             return version_info
 
@@ -291,8 +300,19 @@ class ModelVersionManager:
         if not ollama_model_name:
             ollama_model_name = version_info.get("version_name", version_id)
 
+        # Sanitize for Ollama: lowercase, alphanumeric + hyphens/underscores/dots only.
+        sanitized = re.sub(r"[^a-z0-9._-]", "-", ollama_model_name.lower()).strip("-._")
+        if not sanitized:
+            sanitized = f"model-{version_id}"
+        if sanitized != ollama_model_name:
+            logger.info(f"Sanitized Ollama model name: {ollama_model_name!r} -> {sanitized!r}")
+        ollama_model_name = sanitized
+
         # Create Modelfile
-        modelfile_content = self._create_modelfile(model_path)
+        try:
+            modelfile_content = self._create_modelfile(model_path)
+        except ValueError as e:
+            return {"error": str(e)}
         modelfile_path = self.versions_dir / version_id / "Modelfile"
         try:
             modelfile_path.parent.mkdir(parents=True, exist_ok=True)
@@ -333,6 +353,21 @@ class ModelVersionManager:
         }
 
     @staticmethod
+    def _validate_model_path(path: Path) -> None:
+        """Raise ValueError if *path* contains characters that would break a Modelfile.
+
+        Ollama Modelfiles use whitespace-delimited parsing for ``FROM`` and
+        ``ADAPTER`` directives.  A path containing spaces, tabs, or newlines
+        would silently split across tokens and produce a confusing parse error
+        from ``ollama create`` rather than a clear deployment failure.
+        """
+        raw = str(path)
+        if any(ch.isspace() for ch in raw):
+            raise ValueError(
+                f"Model path contains whitespace and cannot be used in a Modelfile: {raw!r}"
+            )
+
+    @staticmethod
     def _create_modelfile(model_path: str) -> str:
         """Generate a Modelfile for the given model directory.
 
@@ -349,8 +384,15 @@ class ModelVersionManager:
 
         Returns:
             Modelfile content string
+
+        Raises:
+            ValueError: If *model_path* contains whitespace characters.
         """
         p = Path(model_path)
+
+        # Validate paths up-front so a malformed path surfaces as a clear
+        # error instead of a confusing ``ollama create`` parse failure.
+        ModelVersionManager._validate_model_path(p)
 
         # Check for GGUF files first
         gguf_files = list(p.glob("*.gguf"))
@@ -358,16 +400,15 @@ class ModelVersionManager:
             # Pick the largest GGUF deterministically (avoids arbitrary
             # filesystem order when multiple quantizations exist).
             selected = max(gguf_files, key=lambda f: f.stat().st_size)
+            ModelVersionManager._validate_model_path(selected)
             return f"FROM {selected}\n"
 
         # Detect LoRA/PEFT adapter directory — these need ADAPTER syntax,
         # not a bare FROM.  adapter_config.json is the canonical marker.
         if (p / "adapter_config.json").exists():
             try:
-                import json as _json
-
                 with open(p / "adapter_config.json") as f:
-                    cfg = _json.load(f)
+                    cfg = json.load(f)
                 base_model = cfg.get("base_model_name_or_path", "")
                 if base_model:
                     return f"FROM {base_model}\nADAPTER {p}\n"

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -160,9 +160,19 @@ class ModelVersionManager:
 
             # Deploy to Ollama if requested and model files are available
             if deploy and version_info.get("model_path"):
-                deploy_result = await self.deploy_version(
-                    version_id, ollama_model_name=ollama_model_name
-                )
+                try:
+                    deploy_result = await self.deploy_version(
+                        version_id, ollama_model_name=ollama_model_name
+                    )
+                except Exception as deploy_exc:
+                    # Narrow catch: a deploy-time crash (e.g. from
+                    # Path.exists, JSON handling, asyncio.to_thread) must
+                    # not mask the already-persisted registration.
+                    logger.warning(
+                        f"Version {version_id} registered but deployment"
+                        f" raised an unexpected error: {deploy_exc}"
+                    )
+                    deploy_result = {"error": str(deploy_exc)}
                 if "error" in deploy_result:
                     logger.warning(
                         f"Model registered but deployment failed: {deploy_result['error']}"
@@ -292,7 +302,15 @@ class ModelVersionManager:
         Returns:
             Deployment result dict with 'ollama_model' on success or 'error'
         """
-        version_info = self.get_version_info(version_id)
+        # Look up the entry directly in the registry list so mutations
+        # (deployment_status, ollama_model_name, etc.) are guaranteed to
+        # land in self.registry and survive _save_registry(), regardless of
+        # whether get_version_info() returns by reference or by copy.
+        version_info = None
+        for v in self.registry["versions"]:
+            if v["version_id"] == version_id:
+                version_info = v
+                break
         if not version_info:
             return {"error": f"Version {version_id} not found"}
 
@@ -413,7 +431,9 @@ class ModelVersionManager:
             Modelfile content string
 
         Raises:
-            ValueError: If *model_path* contains whitespace characters.
+            ValueError: If *model_path* contains whitespace characters, or
+            if a LoRA/PEFT adapter directory is detected but the base model
+            cannot be determined from ``adapter_config.json``.
         """
         p = Path(model_path)
 
@@ -442,11 +462,13 @@ class ModelVersionManager:
                     return f"FROM {base_model}\nADAPTER {p}\n"
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning(f"adapter_config.json found at {p} but could not be parsed: {e}")
-            # If we can't read the config, fall through to FROM <dir> and
-            # let ollama produce a clear error rather than silently breaking.
-            logger.warning(
-                f"adapter_config.json found at {p} but could not read base model"
-                " — falling back to FROM <dir> which may not work"
+            # An adapter directory without a readable base model reference
+            # cannot be deployed correctly — raise instead of silently
+            # degrading to a bare FROM <dir> which would either confuse
+            # ollama or produce an incorrect model.
+            raise ValueError(
+                f"adapter_config.json found at {p} but base_model_name_or_path"
+                f" is missing or unreadable — cannot build a valid Modelfile"
             )
 
         # HuggingFace directory — point FROM at the directory itself

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -173,6 +173,7 @@ class ModelVersionManager:
                 logger.warning(
                     f"Version {version_id}: deploy=True but no model_path; skipping deployment"
                 )
+                self._save_registry()
                 # NOTE: deploy_version mutates the same dict object that
                 # get_version_info returns (it iterates self.registry["versions"]
                 # and returns the matching entry by reference).  The deployment
@@ -303,31 +304,17 @@ class ModelVersionManager:
 
         # Determine Ollama model name
         if not ollama_model_name:
-            ollama_model_name = version_info.get("version_name", version_id)
+            ollama_model_name = version_info.get("version_name") or version_id
 
         # Sanitize for Ollama: lowercase, alphanumeric + hyphens/underscores/dots only.
+        # Guard against None in case version_name was stored as None.
+        ollama_model_name = ollama_model_name or version_id
         sanitized = re.sub(r"[^a-z0-9._-]", "-", ollama_model_name.lower()).strip("-._")
         if not sanitized:
             sanitized = f"model-{version_id}"
         if sanitized != ollama_model_name:
             logger.info(f"Sanitized Ollama model name: {ollama_model_name!r} -> {sanitized!r}")
         ollama_model_name = sanitized
-
-        # Guard against ollama_model_name collision with another version.
-        # ollama create silently overwrites the tag, but the superseded
-        # version's registry entry would still claim "deployed" under the
-        # same name — making two entries look live for one tag.
-        for other in self.registry["versions"]:
-            if (
-                other["version_id"] != version_id
-                and other.get("ollama_model_name") == ollama_model_name
-            ):
-                other["deployment_status"] = "superseded"
-                logger.info(
-                    f"Marked version {other['version_id']} as superseded: "
-                    f"Ollama model name '{ollama_model_name}' is being reused "
-                    f"by version {version_id}"
-                )
 
         # Create Modelfile
         try:
@@ -357,6 +344,21 @@ class ModelVersionManager:
             version_info["deployment_error"] = deploy_error
             self._save_registry()
             return {"error": deploy_error}
+
+        # Mark superseded *after* successful deployment so a failed
+        # _create_modelfile / ollama create doesn't strand the old version.
+        for other in self.registry["versions"]:
+            if (
+                other["version_id"] != version_id
+                and other.get("ollama_model_name") == ollama_model_name
+                and other.get("deployment_status") == "deployed"
+            ):
+                other["deployment_status"] = "superseded"
+                logger.info(
+                    f"Marked version {other['version_id']} as superseded: "
+                    f"Ollama model name '{ollama_model_name}' is being reused "
+                    f"by version {version_id}"
+                )
 
         # Update registry with success
         version_info["deployment_status"] = "deployed"
@@ -438,6 +440,7 @@ class ModelVersionManager:
                     cfg = json.load(f)
                 base_model = cfg.get("base_model_name_or_path", "")
                 if base_model:
+                    ModelVersionManager._validate_model_path(Path(base_model))
                     return f"FROM {base_model}\nADAPTER {p}\n"
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning(f"adapter_config.json found at {p} but could not be parsed: {e}")

--- a/tests/unit/fine_tuning/test_version_manager_deploy.py
+++ b/tests/unit/fine_tuning/test_version_manager_deploy.py
@@ -1,0 +1,244 @@
+"""Tests for ModelVersionManager deployment functionality."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from evoseal.fine_tuning.version_manager import ModelVersionManager
+
+
+@pytest.fixture
+def versions_dir(tmp_path: Path) -> Path:
+    return tmp_path / "versions"
+
+
+@pytest.fixture
+def model_dir(tmp_path: Path) -> Path:
+    """Create a fake model directory with safetensors-style files."""
+    d = tmp_path / "trained_model"
+    d.mkdir()
+    (d / "config.json").write_text('{"model_type": "test"}')
+    (d / "model.safetensors").write_text("fake-weights")
+    return d
+
+
+@pytest.fixture
+def gguf_model_dir(tmp_path: Path) -> Path:
+    """Create a fake model directory with a GGUF file."""
+    d = tmp_path / "gguf_model"
+    d.mkdir()
+    (d / "model-q4_K_M.gguf").write_text("fake-gguf")
+    return d
+
+
+class TestCreateModelfile:
+    """Tests for _create_modelfile static method."""
+
+    def test_gguf_file_detected(self, gguf_model_dir: Path) -> None:
+        content = ModelVersionManager._create_modelfile(str(gguf_model_dir))
+        assert "FROM" in content
+        assert "model-q4_K_M.gguf" in content
+
+    def test_huggingface_directory_fallback(self, model_dir: Path) -> None:
+        content = ModelVersionManager._create_modelfile(str(model_dir))
+        assert "FROM" in content
+        assert str(model_dir) in content
+
+    def test_empty_directory_falls_back_to_dir(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty_model"
+        empty.mkdir()
+        content = ModelVersionManager._create_modelfile(str(empty))
+        assert "FROM" in content
+        assert str(empty) in content
+
+
+class TestDeployToOllama:
+    """Tests for _deploy_to_ollama static method."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        modelfile = tmp_path / "Modelfile"
+        modelfile.write_text("FROM /some/model\n")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = ""
+            mock_run.return_value.stderr = ""
+            result = ModelVersionManager._deploy_to_ollama(
+                "test-model", modelfile, "http://localhost:11434"
+            )
+        assert result is None
+
+    def test_ollama_not_found(self, tmp_path: Path) -> None:
+        modelfile = tmp_path / "Modelfile"
+        modelfile.write_text("FROM /some/model\n")
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = ModelVersionManager._deploy_to_ollama(
+                "test-model", modelfile, "http://localhost:11434"
+            )
+        assert "not found" in result
+
+    def test_nonzero_exit(self, tmp_path: Path) -> None:
+        modelfile = tmp_path / "Modelfile"
+        modelfile.write_text("FROM /some/model\n")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+            mock_run.return_value.stderr = "model not found"
+            result = ModelVersionManager._deploy_to_ollama(
+                "test-model", modelfile, "http://localhost:11434"
+            )
+        assert "model not found" in result
+
+
+class TestDeployVersion:
+    """Tests for the deploy_version method."""
+
+    @pytest.mark.asyncio
+    async def test_version_not_found(self, versions_dir: Path) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        result = await vm.deploy_version("nonexistent")
+        assert "error" in result
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_model_path(self, versions_dir: Path) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        # Register a version without model files
+        reg = await vm.register_version(
+            training_results={"success": True, "fallback_mode": True},
+            validation_results={"passed": True},
+        )
+        vid = reg["version_id"]
+        # Clear model_path to simulate missing files
+        version_info = vm.get_version_info(vid)
+        version_info.pop("model_path", None)
+        vm._save_registry()
+
+        result = await vm.deploy_version(vid)
+        assert "error" in result
+        assert "not found" in result["error"].lower() or "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_deploy_success(self, versions_dir: Path, model_dir: Path) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        reg = await vm.register_version(
+            training_results={
+                "success": True,
+                "model_save_path": str(model_dir),
+                "fallback_mode": True,
+            },
+            validation_results={"passed": True},
+        )
+        vid = reg["version_id"]
+
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value=None):
+            result = await vm.deploy_version(vid, ollama_model_name="test-deployed")
+
+        assert "ollama_model" in result
+        assert result["ollama_model"] == "test-deployed"
+
+        # Verify registry updated
+        vi = vm.get_version_info(vid)
+        assert vi["deployment_status"] == "deployed"
+        assert vi["ollama_model_name"] == "test-deployed"
+
+    @pytest.mark.asyncio
+    async def test_deploy_failure_updates_registry(
+        self, versions_dir: Path, model_dir: Path
+    ) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        reg = await vm.register_version(
+            training_results={
+                "success": True,
+                "model_save_path": str(model_dir),
+                "fallback_mode": True,
+            },
+            validation_results={"passed": True},
+        )
+        vid = reg["version_id"]
+
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value="some error"):
+            result = await vm.deploy_version(vid)
+
+        assert "error" in result
+        vi = vm.get_version_info(vid)
+        assert vi["deployment_status"] == "failed"
+        assert vi["deployment_error"] == "some error"
+
+
+class TestRegisterVersionWithDeploy:
+    """Tests for register_version with the deploy flag."""
+
+    @pytest.mark.asyncio
+    async def test_register_with_deploy(self, versions_dir: Path, model_dir: Path) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value=None):
+            reg = await vm.register_version(
+                training_results={
+                    "success": True,
+                    "model_save_path": str(model_dir),
+                    "fallback_mode": True,
+                },
+                validation_results={"passed": True},
+                deploy=True,
+                ollama_model_name="auto-deployed",
+            )
+
+        assert reg["deployment_status"] == "deployed"
+        assert reg["ollama_model_name"] == "auto-deployed"
+
+    @pytest.mark.asyncio
+    async def test_register_deploy_failure_still_registers(
+        self, versions_dir: Path, model_dir: Path
+    ) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value="deploy error"):
+            reg = await vm.register_version(
+                training_results={
+                    "success": True,
+                    "model_save_path": str(model_dir),
+                    "fallback_mode": True,
+                },
+                validation_results={"passed": True},
+                deploy=True,
+            )
+
+        # Version should still be registered even if deploy fails
+        assert "version_id" in reg
+        assert reg.get("deployment_error") == "deploy error"
+
+    @pytest.mark.asyncio
+    async def test_register_without_deploy_no_deployment(
+        self, versions_dir: Path, model_dir: Path
+    ) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+
+        reg = await vm.register_version(
+            training_results={
+                "success": True,
+                "model_save_path": str(model_dir),
+                "fallback_mode": True,
+            },
+            validation_results={"passed": True},
+        )
+
+        # Default: no deployment
+        assert reg.get("deployment_status") != "deployed"
+
+
+class TestDeploymentStats:
+    """Test that deployment_distribution is included in statistics."""
+
+    @pytest.mark.asyncio
+    async def test_stats_include_deployment(self, versions_dir: Path) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        await vm.register_version(
+            training_results={"success": True, "fallback_mode": True},
+        )
+        stats = vm.get_version_statistics()
+        assert "deployment_distribution" in stats
+        assert isinstance(stats["deployment_distribution"], dict)

--- a/tests/unit/fine_tuning/test_version_manager_deploy.py
+++ b/tests/unit/fine_tuning/test_version_manager_deploy.py
@@ -55,6 +55,28 @@ class TestCreateModelfile:
         assert "FROM" in content
         assert str(empty) in content
 
+    def test_multiple_gguf_picks_largest(self, tmp_path: Path) -> None:
+        """When multiple GGUF files exist, the largest is selected."""
+        d = tmp_path / "multi_gguf"
+        d.mkdir()
+        small = d / "model-Q4_K_M.gguf"
+        small.write_bytes(b"x" * 100)
+        large = d / "model-Q8_0.gguf"
+        large.write_bytes(b"y" * 500)
+        content = ModelVersionManager._create_modelfile(str(d))
+        assert "model-Q8_0.gguf" in content
+
+    def test_adapter_directory_detected(self, tmp_path: Path) -> None:
+        """LoRA/PEFT adapter dirs produce FROM <base> + ADAPTER <path>."""
+        import json
+
+        d = tmp_path / "adapter_model"
+        d.mkdir()
+        (d / "adapter_config.json").write_text(json.dumps({"base_model_name_or_path": "llama3:8b"}))
+        content = ModelVersionManager._create_modelfile(str(d))
+        assert "FROM llama3:8b" in content
+        assert f"ADAPTER {d}" in content
+
 
 class TestDeployToOllama:
     """Tests for _deploy_to_ollama static method."""
@@ -66,18 +88,14 @@ class TestDeployToOllama:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = ""
             mock_run.return_value.stderr = ""
-            result = ModelVersionManager._deploy_to_ollama(
-                "test-model", modelfile, "http://localhost:11434"
-            )
+            result = ModelVersionManager._deploy_to_ollama("test-model", modelfile)
         assert result is None
 
     def test_ollama_not_found(self, tmp_path: Path) -> None:
         modelfile = tmp_path / "Modelfile"
         modelfile.write_text("FROM /some/model\n")
         with patch("subprocess.run", side_effect=FileNotFoundError):
-            result = ModelVersionManager._deploy_to_ollama(
-                "test-model", modelfile, "http://localhost:11434"
-            )
+            result = ModelVersionManager._deploy_to_ollama("test-model", modelfile)
         assert "not found" in result
 
     def test_nonzero_exit(self, tmp_path: Path) -> None:
@@ -86,9 +104,7 @@ class TestDeployToOllama:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value.returncode = 1
             mock_run.return_value.stderr = "model not found"
-            result = ModelVersionManager._deploy_to_ollama(
-                "test-model", modelfile, "http://localhost:11434"
-            )
+            result = ModelVersionManager._deploy_to_ollama("test-model", modelfile)
         assert "model not found" in result
 
 

--- a/tests/unit/fine_tuning/test_version_manager_deploy.py
+++ b/tests/unit/fine_tuning/test_version_manager_deploy.py
@@ -134,7 +134,7 @@ class TestDeployVersion:
 
         result = await vm.deploy_version(vid)
         assert "error" in result
-        assert "not found" in result["error"].lower() or "not found" in result["error"]
+        assert "not found" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_deploy_success(self, versions_dir: Path, model_dir: Path) -> None:
@@ -244,6 +244,119 @@ class TestRegisterVersionWithDeploy:
 
         # Default: no deployment
         assert reg.get("deployment_status") != "deployed"
+
+
+class TestPathValidation:
+    """Tests for _validate_model_path and path-safe Modelfile generation."""
+
+    def test_path_with_spaces_raises(self, tmp_path: Path) -> None:
+        d = tmp_path / "my model"
+        d.mkdir()
+        (d / "model.gguf").write_bytes(b"x" * 10)
+        with pytest.raises(ValueError, match="whitespace"):
+            ModelVersionManager._create_modelfile(str(d))
+
+    def test_gguf_path_with_spaces_raises(self, tmp_path: Path) -> None:
+        d = tmp_path / "ok_dir"
+        d.mkdir()
+        (d / "my model.gguf").write_bytes(b"x" * 10)
+        with pytest.raises(ValueError, match="whitespace"):
+            ModelVersionManager._create_modelfile(str(d))
+
+    def test_clean_path_succeeds(self, tmp_path: Path) -> None:
+        d = tmp_path / "clean_model"
+        d.mkdir()
+        (d / "model.gguf").write_bytes(b"x" * 10)
+        content = ModelVersionManager._create_modelfile(str(d))
+        assert "FROM" in content
+
+    @pytest.mark.asyncio
+    async def test_deploy_with_spaces_returns_error(
+        self, versions_dir: Path, tmp_path: Path
+    ) -> None:
+        """deploy_version rejects model paths containing whitespace."""
+        d = tmp_path / "ok_model"
+        d.mkdir()
+        (d / "config.json").write_text("{}")
+        (d / "model.safetensors").write_text("fake")
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        reg = await vm.register_version(
+            training_results={
+                "success": True,
+                "model_save_path": str(d),
+                "fallback_mode": True,
+            },
+            validation_results={"passed": True},
+        )
+        vid = reg["version_id"]
+        # Overwrite the stored model_path with one containing spaces to
+        # simulate a space-containing path reaching deploy_version.
+        vi = vm.get_version_info(vid)
+        spaced_dir = tmp_path / "my model"
+        spaced_dir.mkdir()
+        (spaced_dir / "config.json").write_text("{}")
+        (spaced_dir / "model.safetensors").write_text("fake")
+        vi["model_path"] = str(spaced_dir)
+        vm._save_registry()
+
+        result = await vm.deploy_version(vid)
+        assert "error" in result
+        assert "whitespace" in result["error"]
+
+
+class TestModelNameSanitization:
+    """Tests for Ollama model name sanitization in deploy_version."""
+
+    @pytest.mark.asyncio
+    async def test_uppercase_name_lowered(self, versions_dir: Path, model_dir: Path) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        reg = await vm.register_version(
+            training_results={
+                "success": True,
+                "model_save_path": str(model_dir),
+                "fallback_mode": True,
+            },
+            validation_results={"passed": True},
+        )
+        vid = reg["version_id"]
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value=None):
+            result = await vm.deploy_version(vid, ollama_model_name="My-Model")
+        assert result["ollama_model"] == "my-model"
+
+    @pytest.mark.asyncio
+    async def test_spaces_in_name_replaced(self, versions_dir: Path, model_dir: Path) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        reg = await vm.register_version(
+            training_results={
+                "success": True,
+                "model_save_path": str(model_dir),
+                "fallback_mode": True,
+            },
+            validation_results={"passed": True},
+        )
+        vid = reg["version_id"]
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value=None):
+            result = await vm.deploy_version(vid, ollama_model_name="my model v1")
+        assert result["ollama_model"] == "my-model-v1"
+        assert " " not in result["ollama_model"]
+
+    @pytest.mark.asyncio
+    async def test_special_chars_replaced(self, versions_dir: Path, model_dir: Path) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        reg = await vm.register_version(
+            training_results={
+                "success": True,
+                "model_save_path": str(model_dir),
+                "fallback_mode": True,
+            },
+            validation_results={"passed": True},
+        )
+        vid = reg["version_id"]
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value=None):
+            result = await vm.deploy_version(vid, ollama_model_name="model@v1#test")
+        sanitized = result["ollama_model"]
+        assert "@" not in sanitized
+        assert "#" not in sanitized
 
 
 class TestDeploymentStats:

--- a/tests/unit/fine_tuning/test_version_manager_deploy.py
+++ b/tests/unit/fine_tuning/test_version_manager_deploy.py
@@ -359,6 +359,177 @@ class TestModelNameSanitization:
         assert "#" not in sanitized
 
 
+class TestSupersedeAfterDeploy:
+    """Regression: supersede marking must happen after successful deployment."""
+
+    @pytest.mark.asyncio
+    async def test_failed_deploy_does_not_supersede_old(
+        self, versions_dir: Path, model_dir: Path
+    ) -> None:
+        """If ollama create fails, the previously-deployed version must not
+        be marked superseded."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+
+        # Deploy v1 successfully under name "my-model".
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value=None):
+            reg1 = await vm.register_version(
+                training_results={
+                    "success": True,
+                    "model_save_path": str(model_dir),
+                    "fallback_mode": True,
+                },
+                validation_results={"passed": True},
+                deploy=True,
+                ollama_model_name="my-model",
+            )
+        v1_id = reg1["version_id"]
+        v1_info = vm.get_version_info(v1_id)
+        assert v1_info["deployment_status"] == "deployed"
+
+        # Attempt v2 deploy under the same name, but ollama create fails.
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value="boom"):
+            reg2 = await vm.register_version(
+                training_results={
+                    "success": True,
+                    "model_save_path": str(model_dir),
+                    "fallback_mode": True,
+                },
+                validation_results={"passed": True},
+                deploy=True,
+                ollama_model_name="my-model",
+            )
+        v2_id = reg2["version_id"]
+
+        # v1 must still be "deployed", NOT "superseded".
+        v1_info = vm.get_version_info(v1_id)
+        assert v1_info["deployment_status"] == "deployed"
+        # v2 should be "failed".
+        v2_info = vm.get_version_info(v2_id)
+        assert v2_info["deployment_status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_successful_deploy_supersedes_old(
+        self, versions_dir: Path, model_dir: Path
+    ) -> None:
+        """When a new version deploys successfully under the same name,
+        the old version should be marked superseded."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value=None):
+            reg1 = await vm.register_version(
+                training_results={
+                    "success": True,
+                    "model_save_path": str(model_dir),
+                    "fallback_mode": True,
+                },
+                validation_results={"passed": True},
+                deploy=True,
+                ollama_model_name="my-model",
+            )
+        v1_id = reg1["version_id"]
+
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value=None):
+            reg2 = await vm.register_version(
+                training_results={
+                    "success": True,
+                    "model_save_path": str(model_dir),
+                    "fallback_mode": True,
+                },
+                validation_results={"passed": True},
+                deploy=True,
+                ollama_model_name="my-model",
+            )
+        v2_id = reg2["version_id"]
+
+        v1_info = vm.get_version_info(v1_id)
+        assert v1_info["deployment_status"] == "superseded"
+        v2_info = vm.get_version_info(v2_id)
+        assert v2_info["deployment_status"] == "deployed"
+
+    @pytest.mark.asyncio
+    async def test_modelfile_failure_does_not_supersede_old(
+        self, versions_dir: Path, model_dir: Path
+    ) -> None:
+        """If _create_modelfile raises, the previously-deployed version must
+        not be marked superseded."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+
+        with patch.object(ModelVersionManager, "_deploy_to_ollama", return_value=None):
+            reg1 = await vm.register_version(
+                training_results={
+                    "success": True,
+                    "model_save_path": str(model_dir),
+                    "fallback_mode": True,
+                },
+                validation_results={"passed": True},
+                deploy=True,
+                ollama_model_name="my-model",
+            )
+        v1_id = reg1["version_id"]
+
+        # Make _create_modelfile fail for v2.
+        with patch.object(
+            ModelVersionManager,
+            "_create_modelfile",
+            side_effect=ValueError("bad path"),
+        ):
+            reg2 = await vm.register_version(
+                training_results={
+                    "success": True,
+                    "model_save_path": str(model_dir),
+                    "fallback_mode": True,
+                },
+                validation_results={"passed": True},
+                deploy=True,
+                ollama_model_name="my-model",
+            )
+        v2_id = reg2["version_id"]
+
+        v1_info = vm.get_version_info(v1_id)
+        assert v1_info["deployment_status"] == "deployed"
+        v2_info = vm.get_version_info(v2_id)
+        assert v2_info["deployment_status"] == "failed"
+
+
+class TestAdapterBaseModelValidation:
+    """Regression: base_model from adapter_config must be validated."""
+
+    def test_adapter_base_model_with_spaces_raises(self, tmp_path: Path) -> None:
+        d = tmp_path / "adapter_model"
+        d.mkdir()
+        (d / "adapter_config.json").write_text(
+            json.dumps({"base_model_name_or_path": "my base model"})
+        )
+        with pytest.raises(ValueError, match="whitespace"):
+            ModelVersionManager._create_modelfile(str(d))
+
+    def test_adapter_base_model_without_spaces_succeeds(self, tmp_path: Path) -> None:
+        d = tmp_path / "adapter_model"
+        d.mkdir()
+        (d / "adapter_config.json").write_text(json.dumps({"base_model_name_or_path": "llama3:8b"}))
+        content = ModelVersionManager._create_modelfile(str(d))
+        assert "FROM llama3:8b" in content
+        assert f"ADAPTER {d}" in content
+
+
+class TestNoModelPathPersistError:
+    """Regression: deploy-requested-but-no-model_path must persist to registry."""
+
+    @pytest.mark.asyncio
+    async def test_error_persisted_to_disk(self, versions_dir: Path) -> None:
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        reg = await vm.register_version(
+            training_results={"success": True, "fallback_mode": True},
+            deploy=True,
+        )
+        vid = reg["version_id"]
+
+        # Re-load from disk to verify persistence.
+        vm2 = ModelVersionManager(versions_dir=versions_dir)
+        vi = vm2.get_version_info(vid)
+        assert vi["deployment_error"] == "deploy requested but no model_path available"
+
+
 class TestDeploymentStats:
     """Test that deployment_distribution is included in statistics."""
 

--- a/tests/unit/fine_tuning/test_version_manager_deploy.py
+++ b/tests/unit/fine_tuning/test_version_manager_deploy.py
@@ -78,6 +78,50 @@ class TestCreateModelfile:
         assert f"ADAPTER {d}" in content
 
 
+class TestRegisterVersionDeployException:
+    """Regression: non-ValueError from deploy must not mask registration."""
+
+    @pytest.mark.asyncio
+    async def test_unexpected_deploy_error_still_returns_version(
+        self, versions_dir: Path, model_dir: Path
+    ) -> None:
+        """A non-ValueError raised during deploy should not cause
+        register_version to return an error dict — the version was already
+        persisted to the registry."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+
+        # Patch _deploy_to_ollama to raise a non-ValueError (e.g. OSError).
+        with patch.object(
+            ModelVersionManager,
+            "_deploy_to_ollama",
+            side_effect=OllamaSpawnError("unexpected boom"),
+        ):
+            reg = await vm.register_version(
+                training_results={
+                    "success": True,
+                    "model_save_path": str(model_dir),
+                    "fallback_mode": True,
+                },
+                validation_results={"passed": True},
+                deploy=True,
+                ollama_model_name="boom-test",
+            )
+
+        # The version must be registered (not an error dict).
+        assert "version_id" in reg
+        assert "error" not in reg
+        # The version should still be in the registry.
+        vi = vm.get_version_info(reg["version_id"])
+        assert vi is not None
+        assert vi["status"] == "stored"
+
+
+class OllamaSpawnError(OSError):
+    """Test stand-in for an unexpected OS-level error during deploy."""
+
+    pass
+
+
 class TestDeployToOllama:
     """Tests for _deploy_to_ollama static method."""
 
@@ -511,6 +555,30 @@ class TestAdapterBaseModelValidation:
         content = ModelVersionManager._create_modelfile(str(d))
         assert "FROM llama3:8b" in content
         assert f"ADAPTER {d}" in content
+
+    def test_adapter_missing_base_model_raises(self, tmp_path: Path) -> None:
+        """adapter_config.json with no base_model_name_or_path raises ValueError."""
+        d = tmp_path / "adapter_no_base"
+        d.mkdir()
+        (d / "adapter_config.json").write_text(json.dumps({"r": 8}))
+        with pytest.raises(ValueError, match="base_model_name_or_path"):
+            ModelVersionManager._create_modelfile(str(d))
+
+    def test_adapter_empty_base_model_raises(self, tmp_path: Path) -> None:
+        """adapter_config.json with empty base_model_name_or_path raises ValueError."""
+        d = tmp_path / "adapter_empty_base"
+        d.mkdir()
+        (d / "adapter_config.json").write_text(json.dumps({"base_model_name_or_path": ""}))
+        with pytest.raises(ValueError, match="base_model_name_or_path"):
+            ModelVersionManager._create_modelfile(str(d))
+
+    def test_adapter_unparseable_config_raises(self, tmp_path: Path) -> None:
+        """Corrupt adapter_config.json raises ValueError instead of degrading."""
+        d = tmp_path / "adapter_bad_json"
+        d.mkdir()
+        (d / "adapter_config.json").write_text("not valid json")
+        with pytest.raises(ValueError, match="base_model_name_or_path"):
+            ModelVersionManager._create_modelfile(str(d))
 
 
 class TestNoModelPathPersistError:

--- a/tests/unit/fine_tuning/test_version_manager_deploy.py
+++ b/tests/unit/fine_tuning/test_version_manager_deploy.py
@@ -226,6 +226,7 @@ class TestRegisterVersionWithDeploy:
         # Version should still be registered even if deploy fails
         assert "version_id" in reg
         assert reg.get("deployment_error") == "deploy error"
+        assert reg["deployment_status"] == "failed"
 
     @pytest.mark.asyncio
     async def test_register_without_deploy_no_deployment(
@@ -528,6 +529,7 @@ class TestNoModelPathPersistError:
         vm2 = ModelVersionManager(versions_dir=versions_dir)
         vi = vm2.get_version_info(vid)
         assert vi["deployment_error"] == "deploy requested but no model_path available"
+        assert vi["deployment_status"] == "failed"
 
 
 class TestDeploymentStats:


### PR DESCRIPTION
## What

Add `deploy_version()` method to `ModelVersionManager` that creates a Modelfile and runs `ollama create` so the serving layer (OllamaProvider) can actually load fine-tuned models. Previously, `register_version` only copied weights and updated a JSON registry — the model was never registered with Ollama.

## Changes

- **`evoseal/fine_tuning/version_manager.py`**: Added three new methods:
  - `deploy_version(version_id, ollama_model_name, base_url)` — public method that orchestrates deployment: creates Modelfile, runs `ollama create`, updates registry
  - `_create_modelfile(model_path)` — generates Modelfile content (handles both GGUF and HuggingFace-safetensors directories)
  - `_deploy_to_ollama(model_name, modelfile_path, base_url)` — runs `ollama create` via subprocess
  - Updated `register_version()` with `deploy=True` keyword arg to auto-deploy after registration
  - Added `deployment_distribution` to `get_version_statistics()`
- **`tests/unit/fine_tuning/test_version_manager_deploy.py`**: 14 unit tests covering success/failure paths, edge cases, and the register+deploy integration
- **`TODO.md`**: Checked off P2-4

## Why

Addresses TODO.md item P2-4: "Implement real model deployment". This is step 4 of 6 in closing the bidirectional co-evolution loop. Without this, the fine-tuned model weights sit in a version directory but are never loadable by the serving layer.

## Verification

```
ruff format --check .        ✅ 298 files formatted
ruff check evoseal/ tests/   ✅ All checks passed
pytest (full suite)           ✅ 512 passed, 23 deselected
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional automatic deployment of newly registered fine-tuned models to Ollama, with configurable deployment naming.
  - Added explicit deployment with recorded status, deployed model name, and timestamp.
  - Expanded deployment support for GGUF, adapter/LoRA-style, and directory-based model layouts, including conflict handling for overlapping deployment names.
  - Version statistics now include a deployment-status distribution.
- **Bug Fixes**
  - Improved deployment error reporting and refreshed the local installed-model cache after successful deployments.
- **Tests**
  - Added unit coverage for Modelfile creation, deployment success/failure paths, and statistics.
- **Documentation**
  - Updated project tracking to mark real model deployment as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->