### PR TITLE
feat: wire generation to consult fine-tuning registry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -171,7 +171,7 @@
 - [x] **FIX: training call used nonexistent method** _(done 2026-07-19, commit fix/training-method-name-bug, on `main` as of 81156b3)_ — `continuous_evolution_service.py:234` called `training_manager.start_training()` which did not exist; changed to `run_training_cycle()` and fixed `validation_passed` → `validation_results.passed`
 - [x] **3. validate_model must serve the fine-tuned model, not baseline** _(done 2026-07-21)_ — all 5 test suites now use `model_path` when provided via `_resolve_model_for_validation()`; removed dead `TRANSFORMERS_AVAILABLE` import block. **Known limitation:** `model_path` must be an Ollama-resolvable model tag — directory paths from `register_version()` will surface an Ollama error until item 4 (real deployment) lands.
 - [x] **4. Implement real model deployment** — `version_manager.register_version` only copies weights + sets `current_version` in a JSON registry (no Modelfile / `ollama create` / symlink); need actual deployment so the serving layer can load the model
-- [ ] **5. Generation must consult the fine-tuning registry** — `version_manager.get_current_version()` has zero callers — the generator (`providers/local_models.py resolve_model`, which currently just reads raw installed Ollama tags) must consult the registry instead so the deployed fine-tuned model actually gets used
+- [x] **5. Generation must consult the fine-tuning registry** — `version_manager.get_current_version()` has zero callers — the generator (`providers/local_models.py resolve_model`, which currently just reads raw installed Ollama tags) must consult the registry instead so the deployed fine-tuned model actually gets used
 - [ ] **6. Wire bidirectional_manager to orchestrate the full loop** — `bidirectional_manager.py`'s docstring promises evolve → collect → train → deploy → repeat, but the class only implements reporting/statistics methods (`get_evolution_status`, `get_evolution_history`, `generate_evolution_report`); no method actually drives the sequence end-to-end
 - [ ] **Add end-to-end bidirectional loop test** — exercise the full cycle: collect → train → validate → deploy → regenerate; no such test exists today (write once steps 1–6 land)
 
@@ -303,9 +303,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 10   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
-| 🟡 P2    | 29    | 5    | Co-evolution loop gaps (7 items, 5 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
+| 🟡 P2    | 29    | 6    | Co-evolution loop gaps (7 items, 6 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
 | 🟢 P3    | 24    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
-| **Total** | **88** | **32** | |
+| **Total** | **88** | **33** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -171,7 +171,7 @@
 - [x] **FIX: training call used nonexistent method** _(done 2026-07-19, commit fix/training-method-name-bug, on `main` as of 81156b3)_ — `continuous_evolution_service.py:234` called `training_manager.start_training()` which did not exist; changed to `run_training_cycle()` and fixed `validation_passed` → `validation_results.passed`
 - [x] **3. validate_model must serve the fine-tuned model, not baseline** _(done 2026-07-21)_ — all 5 test suites now use `model_path` when provided via `_resolve_model_for_validation()`; removed dead `TRANSFORMERS_AVAILABLE` import block. **Known limitation:** `model_path` must be an Ollama-resolvable model tag — directory paths from `register_version()` will surface an Ollama error until item 4 (real deployment) lands.
 - [x] **4. Implement real model deployment** — `version_manager.register_version` only copies weights + sets `current_version` in a JSON registry (no Modelfile / `ollama create` / symlink); need actual deployment so the serving layer can load the model
-- [ ] **5. Generation must consult the fine-tuning registry** — `version_manager.get_current_version()` has zero callers — the generator (`providers/local_models.py resolve_model`, which currently just reads raw installed Ollama tags) must consult the registry instead so the deployed fine-tuned model actually gets used
+- [x] **5. Generation must consult the fine-tuning registry** _(done 2026-07-24, PR #73)_ — `default_manager()` now calls `ModelVersionManager().get_current_version()` and passes the deployed model's Ollama tag as `registry_model` to `CoevolutionManager`, so the coder provider prefers the fine-tuned model over raw family-based discovery
 - [ ] **6. Wire bidirectional_manager to orchestrate the full loop** — `bidirectional_manager.py`'s docstring promises evolve → collect → train → deploy → repeat, but the class only implements reporting/statistics methods (`get_evolution_status`, `get_evolution_history`, `generate_evolution_report`); no method actually drives the sequence end-to-end
 - [ ] **Add end-to-end bidirectional loop test** — exercise the full cycle: collect → train → validate → deploy → regenerate; no such test exists today (write once steps 1–6 land)
 
@@ -303,9 +303,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 10   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
-| 🟡 P2    | 29    | 5    | Co-evolution loop gaps (7 items, 5 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
+| 🟡 P2    | 29    | 6    | Co-evolution loop gaps (7 items, 6 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
 | 🟢 P3    | 24    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
-| **Total** | **88** | **32** | |
+| **Total** | **88** | **33** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -171,7 +171,7 @@
 - [x] **FIX: training call used nonexistent method** _(done 2026-07-19, commit fix/training-method-name-bug, on `main` as of 81156b3)_ — `continuous_evolution_service.py:234` called `training_manager.start_training()` which did not exist; changed to `run_training_cycle()` and fixed `validation_passed` → `validation_results.passed`
 - [x] **3. validate_model must serve the fine-tuned model, not baseline** _(done 2026-07-21)_ — all 5 test suites now use `model_path` when provided via `_resolve_model_for_validation()`; removed dead `TRANSFORMERS_AVAILABLE` import block. **Known limitation:** `model_path` must be an Ollama-resolvable model tag — directory paths from `register_version()` will surface an Ollama error until item 4 (real deployment) lands.
 - [x] **4. Implement real model deployment** — `version_manager.register_version` only copies weights + sets `current_version` in a JSON registry (no Modelfile / `ollama create` / symlink); need actual deployment so the serving layer can load the model
-- [x] **5. Generation must consult the fine-tuning registry** — `version_manager.get_current_version()` has zero callers — the generator (`providers/local_models.py resolve_model`, which currently just reads raw installed Ollama tags) must consult the registry instead so the deployed fine-tuned model actually gets used
+- [ ] **5. Generation must consult the fine-tuning registry** — `version_manager.get_current_version()` has zero callers — the generator (`providers/local_models.py resolve_model`, which currently just reads raw installed Ollama tags) must consult the registry instead so the deployed fine-tuned model actually gets used
 - [ ] **6. Wire bidirectional_manager to orchestrate the full loop** — `bidirectional_manager.py`'s docstring promises evolve → collect → train → deploy → repeat, but the class only implements reporting/statistics methods (`get_evolution_status`, `get_evolution_history`, `generate_evolution_report`); no method actually drives the sequence end-to-end
 - [ ] **Add end-to-end bidirectional loop test** — exercise the full cycle: collect → train → validate → deploy → regenerate; no such test exists today (write once steps 1–6 land)
 
@@ -303,9 +303,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 10   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
-| 🟡 P2    | 29    | 6    | Co-evolution loop gaps (7 items, 6 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
+| 🟡 P2    | 29    | 5    | Co-evolution loop gaps (7 items, 5 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
 | 🟢 P3    | 24    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
-| **Total** | **88** | **33** | |
+| **Total** | **88** | **32** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/evoseal/prompt_evolution/coevolution_manager.py
+++ b/evoseal/prompt_evolution/coevolution_manager.py
@@ -84,6 +84,11 @@ class CoevolutionManager:
         self.coder = coder_provider or OllamaProvider(
             base_url=base_url, role=AgentRole.CODER, registry_model=registry_model
         )
+        # NOTE: registry_model is only forwarded to the coder provider because
+        # ModelVersionManager tracks a single current_version with no role
+        # distinction — the fine-tuning loop currently manages one model, not
+        # separate coder/reviewer models.  If the registry gains per-role
+        # tracking, pass it here too.
         self.reviewer = reviewer_provider or OllamaProvider(
             base_url=base_url, role=AgentRole.REVIEWER
         )

--- a/evoseal/prompt_evolution/coevolution_manager.py
+++ b/evoseal/prompt_evolution/coevolution_manager.py
@@ -23,6 +23,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from evoseal.fine_tuning.version_manager import ModelVersionManager
 from evoseal.providers.local_models import (
     DEFAULT_OLLAMA_BASE_URL,
     AgentRole,
@@ -278,5 +279,20 @@ class CoevolutionManager:
 
 
 def default_manager(base_dir: Path | str | None = None) -> CoevolutionManager:
-    """Convenience factory: a manager backed by discovered local models."""
-    return CoevolutionManager(prompt_store=PromptStore(base_dir))
+    """Convenience factory: a manager backed by discovered local models.
+
+    If the fine-tuning registry has a currently deployed model, its Ollama
+    tag is passed as ``registry_model`` so the coder provider prefers it
+    over raw family-based discovery.
+    """
+    registry_model: str | None = None
+    try:
+        current = ModelVersionManager().get_current_version()
+        if current and current.get("deployment_status") == "deployed":
+            registry_model = current.get("ollama_model_name")
+    except Exception:
+        logger.warning(
+            "Could not read fine-tuning registry; falling back to family-based model discovery",
+            exc_info=True,
+        )
+    return CoevolutionManager(prompt_store=PromptStore(base_dir), registry_model=registry_model)

--- a/evoseal/prompt_evolution/coevolution_manager.py
+++ b/evoseal/prompt_evolution/coevolution_manager.py
@@ -76,9 +76,14 @@ class CoevolutionManager:
         accept_threshold: float = 0.7,
         min_score_gain: float = 0.05,
         coder_seed_prompt: str = DEFAULT_CODER_PROMPT,
+        registry_model: str | None = None,
     ) -> None:
         # Providers resolve their model from what is installed (see local_models).
-        self.coder = coder_provider or OllamaProvider(base_url=base_url, role=AgentRole.CODER)
+        # When *registry_model* is given the coder provider prefers the
+        # fine-tuned model from the version registry.
+        self.coder = coder_provider or OllamaProvider(
+            base_url=base_url, role=AgentRole.CODER, registry_model=registry_model
+        )
         self.reviewer = reviewer_provider or OllamaProvider(
             base_url=base_url, role=AgentRole.REVIEWER
         )

--- a/evoseal/providers/local_models.py
+++ b/evoseal/providers/local_models.py
@@ -134,14 +134,25 @@ def list_installed_models(
 
 
 def select_model(
-    role: AgentRole, available: list[str], *, override: str | None = None
+    role: AgentRole,
+    available: list[str],
+    *,
+    override: str | None = None,
+    registry_model: str | None = None,
 ) -> str | None:
     """Pick the best installed model for ``role`` from ``available``.
 
     Resolution order: explicit ``override`` -> the role's environment override
-    (``EVOSEAL_CODER_MODEL`` / ``EVOSEAL_REVIEWER_MODEL``) -> family preferences.
+    (``EVOSEAL_CODER_MODEL`` / ``EVOSEAL_REVIEWER_MODEL``) -> fine-tuning
+    registry (``registry_model``) -> family preferences.
+
     Each override wins only when it is actually installed (exact or substring
-    match). Returns ``None`` when nothing suitable is installed, so the caller can
+    match).  ``registry_model`` is the Ollama model name of the currently
+    deployed fine-tuned model from :class:`ModelVersionManager` — when
+    provided and installed it is preferred over raw family-based discovery so
+    the generation loop actually uses the fine-tuned weights.
+
+    Returns ``None`` when nothing suitable is installed, so the caller can
     fall back to a known-good tag rather than pick an arbitrary model: an
     embedding model, say, must never be selected to write code.
     """
@@ -160,6 +171,28 @@ def select_model(
             source,
         )
 
+    # Prefer the fine-tuned model from the version registry when it is
+    # actually installed in Ollama.  This is the key wiring that makes the
+    # bidirectional co-evolution loop close: the generator consults the
+    # registry instead of only looking at raw installed tags.
+    if registry_model:
+        if registry_model in available:
+            logger.info(
+                "Using registry-deployed model %s for role %s",
+                registry_model,
+                role.value,
+            )
+            return registry_model
+        for name in available:
+            if registry_model.lower() in name.lower():
+                logger.info(
+                    "Using registry-deployed model %s (matched %s) for role %s",
+                    registry_model,
+                    name,
+                    role.value,
+                )
+                return name
+
     for family in ROLE_MODEL_PREFERENCES.get(role, ()):
         for name in available:
             if family.lower() in name.lower():
@@ -174,17 +207,20 @@ def resolve_model(
     base_url: str = DEFAULT_OLLAMA_BASE_URL,
     override: str | None = None,
     available: list[str] | None = None,
+    registry_model: str | None = None,
 ) -> str:
     """Resolve the concrete Ollama model name to use for ``role``.
 
     Queries Ollama (cached) when ``available`` is not supplied. Honors the role's
-    environment override. Falls back to a canonical tag when Ollama is unreachable
-    or has no suitable model installed.
+    environment override. When *registry_model* is given (the Ollama tag of the
+    currently deployed fine-tuned model from the version registry) it is preferred
+    over raw family-based discovery. Falls back to a canonical tag when Ollama is
+    unreachable or has no suitable model installed.
     """
     if available is None:
         available = list_installed_models(base_url)
 
-    chosen = select_model(role, available, override=override)
+    chosen = select_model(role, available, override=override, registry_model=registry_model)
     if chosen:
         logger.info("Resolved %s model -> %s", role.value, chosen)
         return chosen
@@ -203,13 +239,19 @@ def resolve_role_models(
     base_url: str = DEFAULT_OLLAMA_BASE_URL,
     overrides: dict[AgentRole, str] | None = None,
     roles: tuple[AgentRole, ...] = (AgentRole.CODER, AgentRole.REVIEWER),
+    registry_models: dict[AgentRole, str] | None = None,
 ) -> dict[AgentRole, str]:
     """Resolve models for several roles with a single Ollama query."""
     overrides = overrides or {}
+    registry_models = registry_models or {}
     available = list_installed_models(base_url)
     return {
         role: resolve_model(
-            role, base_url=base_url, override=overrides.get(role), available=available
+            role,
+            base_url=base_url,
+            override=overrides.get(role),
+            available=available,
+            registry_model=registry_models.get(role),
         )
         for role in roles
     }

--- a/evoseal/providers/local_models.py
+++ b/evoseal/providers/local_models.py
@@ -177,27 +177,38 @@ def select_model(
     # registry instead of only looking at raw installed tags.
     if registry_model:
         registry_lower = registry_model.lower()
-        # Case-insensitive exact match — return the installed tag, not the
-        # input, so the caller gets the canonical casing Ollama uses.
+        role_families = ROLE_MODEL_PREFERENCES.get(role, ())
         for name in available:
-            if name.lower() == registry_lower:
-                logger.info(
-                    "Using registry-deployed model %s for role %s",
-                    name,
-                    role.value,
-                )
-                return name
-        # Substring fallback (e.g. registry says "model:v2" but installed
-        # tag is "model:v2-quantized").
-        for name in available:
-            if registry_lower in name.lower():
-                logger.info(
-                    "Using registry-deployed model %s (matched %s) for role %s",
+            name_lower = name.lower()
+            exact = name_lower == registry_lower
+            substring = not exact and registry_lower in name_lower
+            if not (exact or substring):
+                continue
+            # Guard: the matched tag must belong to this role's model
+            # families so that e.g. an embedding model tag cannot be
+            # returned for the CODER role.
+            if role_families and not any(fam.lower() in name_lower for fam in role_families):
+                logger.warning(
+                    "Registry model %s matches installed tag %s but does "
+                    "not belong to role %s families; skipping",
                     registry_model,
                     name,
                     role.value,
                 )
-                return name
+                continue
+            logger.info(
+                "Using registry-deployed model %s%s for role %s",
+                name,
+                " (matched %s)" % registry_model if substring else "",
+                role.value,
+            )
+            return name
+        logger.warning(
+            "Registry model %r is not installed or not suitable for role %s; "
+            "falling back to family discovery",
+            registry_model,
+            role.value,
+        )
 
     for family in ROLE_MODEL_PREFERENCES.get(role, ()):
         for name in available:

--- a/evoseal/providers/local_models.py
+++ b/evoseal/providers/local_models.py
@@ -178,16 +178,35 @@ def select_model(
     if registry_model:
         registry_lower = registry_model.lower()
         role_families = ROLE_MODEL_PREFERENCES.get(role, ())
+
+        def _family_ok(name_lower: str) -> bool:
+            """Return True if *name_lower* belongs to this role's families.
+
+            When *role_families* is empty (e.g. MAIN has no preferences)
+            the match is rejected rather than silently bypassing the guard.
+            """
+            if not role_families:
+                return False
+            return any(fam.lower() in name_lower for fam in role_families)
+
+        # Two-pass matching: prefer an exact tag match over a substring
+        # match so that e.g. ``deepseek-coder-finetuned:v2`` is not
+        # shadowed by a similarly-named ``deepseek-coder-finetuned:v2-old``
+        # that happens to appear earlier in the installed list.
+        substring_candidate: str | None = None
         for name in available:
             name_lower = name.lower()
-            exact = name_lower == registry_lower
-            substring = not exact and registry_lower in name_lower
-            if not (exact or substring):
-                continue
-            # Guard: the matched tag must belong to this role's model
-            # families so that e.g. an embedding model tag cannot be
-            # returned for the CODER role.
-            if role_families and not any(fam.lower() in name_lower for fam in role_families):
+            if name_lower == registry_lower:
+                if _family_ok(name_lower):
+                    logger.info(
+                        "Using registry-deployed model %s for role %s",
+                        name,
+                        role.value,
+                    )
+                    return name
+                # Exact match but wrong family — still record as a
+                # candidate so we can warn rather than silently fall
+                # through.
                 logger.warning(
                     "Registry model %s matches installed tag %s but does "
                     "not belong to role %s families; skipping",
@@ -195,14 +214,21 @@ def select_model(
                     name,
                     role.value,
                 )
-                continue
+            elif substring_candidate is None and registry_lower in name_lower:
+                # Remember the first substring match; keep scanning for
+                # an exact match that may appear later.
+                if _family_ok(name_lower):
+                    substring_candidate = name
+
+        if substring_candidate is not None:
             logger.info(
-                "Using registry-deployed model %s%s for role %s",
-                name,
-                " (matched %s)" % registry_model if substring else "",
+                "Using registry-deployed model %s (matched %s) for role %s",
+                substring_candidate,
+                registry_model,
                 role.value,
             )
-            return name
+            return substring_candidate
+
         logger.warning(
             "Registry model %r is not installed or not suitable for role %s; "
             "falling back to family discovery",

--- a/evoseal/providers/local_models.py
+++ b/evoseal/providers/local_models.py
@@ -176,15 +176,21 @@ def select_model(
     # bidirectional co-evolution loop close: the generator consults the
     # registry instead of only looking at raw installed tags.
     if registry_model:
-        if registry_model in available:
-            logger.info(
-                "Using registry-deployed model %s for role %s",
-                registry_model,
-                role.value,
-            )
-            return registry_model
+        registry_lower = registry_model.lower()
+        # Case-insensitive exact match — return the installed tag, not the
+        # input, so the caller gets the canonical casing Ollama uses.
         for name in available:
-            if registry_model.lower() in name.lower():
+            if name.lower() == registry_lower:
+                logger.info(
+                    "Using registry-deployed model %s for role %s",
+                    name,
+                    role.value,
+                )
+                return name
+        # Substring fallback (e.g. registry says "model:v2" but installed
+        # tag is "model:v2-quantized").
+        for name in available:
+            if registry_lower in name.lower():
                 logger.info(
                     "Using registry-deployed model %s (matched %s) for role %s",
                     registry_model,

--- a/evoseal/providers/ollama_provider.py
+++ b/evoseal/providers/ollama_provider.py
@@ -30,6 +30,7 @@ class OllamaProvider(SEALProvider):
         model: str | None = None,
         timeout: int = 120,
         role: AgentRole | str = AgentRole.CODER,
+        registry_model: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the Ollama provider.
@@ -41,12 +42,18 @@ class OllamaProvider(SEALProvider):
             timeout: Request timeout in seconds (default: 120)
             role: Role ("coder"/"reviewer") to resolve a default model for when
                 ``model`` is None. Accepts an :class:`AgentRole` or its string value.
+            registry_model: Ollama model name of the currently deployed
+                fine-tuned model from the version registry.  When provided and
+                installed, it is preferred over raw family-based discovery.
             **kwargs: Additional configuration options
         """
         self.base_url = base_url.rstrip("/")
         resolved_role = role if isinstance(role, AgentRole) else AgentRole(role)
         # Resolve against what is actually installed rather than assuming a tag.
-        self.model = model or resolve_model(resolved_role, base_url=self.base_url)
+        # When *registry_model* is given the fine-tuned model is preferred.
+        self.model = model or resolve_model(
+            resolved_role, base_url=self.base_url, registry_model=registry_model
+        )
         self.timeout = timeout
         self.config = kwargs
 

--- a/tests/unit/prompt_evolution/test_coevolution_manager.py
+++ b/tests/unit/prompt_evolution/test_coevolution_manager.py
@@ -215,3 +215,117 @@ def test_score_parsing_variants():
 def test_issue_parsing_none():
     assert CoevolutionManager._parse_issues("- none\nSCORE: 9/10") == []
     assert CoevolutionManager._parse_issues("- a\n- b\nSCORE: 5/10") == ["a", "b"]
+
+
+# -- default_manager registry wiring tests --
+
+
+def test_default_manager_passes_deployed_registry_model(monkeypatch, tmp_path):
+    """A deployed current version is consulted and passed as registry_model."""
+    from evoseal.prompt_evolution import coevolution_manager
+
+    class FakeVersionManager:
+        def get_current_version(self):
+            return {
+                "deployment_status": "deployed",
+                "ollama_model_name": "deepseek-coder-finetuned:v2",
+            }
+
+    monkeypatch.setattr(
+        coevolution_manager,
+        "ModelVersionManager",
+        FakeVersionManager,
+    )
+    captured = {}
+    original_init = CoevolutionManager.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured["registry_model"] = kwargs.get("registry_model")
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(CoevolutionManager, "__init__", spy_init)
+
+    coevolution_manager.default_manager(base_dir=tmp_path / "d")
+    assert captured["registry_model"] == "deepseek-coder-finetuned:v2"
+
+
+def test_default_manager_no_current_version_falls_back(monkeypatch, tmp_path):
+    """No current version falls back to registry_model=None."""
+    from evoseal.prompt_evolution import coevolution_manager
+
+    class FakeVersionManager:
+        def get_current_version(self):
+            return None
+
+    monkeypatch.setattr(
+        coevolution_manager,
+        "ModelVersionManager",
+        FakeVersionManager,
+    )
+    captured = {}
+    original_init = CoevolutionManager.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured["registry_model"] = kwargs.get("registry_model")
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(CoevolutionManager, "__init__", spy_init)
+
+    coevolution_manager.default_manager(base_dir=tmp_path / "d")
+    assert captured["registry_model"] is None
+
+
+def test_default_manager_non_deployed_version_falls_back(monkeypatch, tmp_path):
+    """A version present but not 'deployed' falls back to registry_model=None."""
+    from evoseal.prompt_evolution import coevolution_manager
+
+    class FakeVersionManager:
+        def get_current_version(self):
+            return {
+                "deployment_status": "pending",
+                "ollama_model_name": "deepseek-coder-finetuned:v2",
+            }
+
+    monkeypatch.setattr(
+        coevolution_manager,
+        "ModelVersionManager",
+        FakeVersionManager,
+    )
+    captured = {}
+    original_init = CoevolutionManager.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured["registry_model"] = kwargs.get("registry_model")
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(CoevolutionManager, "__init__", spy_init)
+
+    coevolution_manager.default_manager(base_dir=tmp_path / "d")
+    assert captured["registry_model"] is None
+
+
+def test_default_manager_registry_exception_degrades_gracefully(monkeypatch, tmp_path):
+    """get_current_version raising degrades to registry_model=None, not a crash."""
+    from evoseal.prompt_evolution import coevolution_manager
+
+    class BrokenVersionManager:
+        def get_current_version(self):
+            raise FileNotFoundError("registry.json missing")
+
+    monkeypatch.setattr(
+        coevolution_manager,
+        "ModelVersionManager",
+        BrokenVersionManager,
+    )
+    captured = {}
+    original_init = CoevolutionManager.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured["registry_model"] = kwargs.get("registry_model")
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(CoevolutionManager, "__init__", spy_init)
+
+    mgr = coevolution_manager.default_manager(base_dir=tmp_path / "d")
+    assert captured["registry_model"] is None
+    assert isinstance(mgr, CoevolutionManager)

--- a/tests/unit/providers/test_local_models.py
+++ b/tests/unit/providers/test_local_models.py
@@ -206,3 +206,71 @@ def test_resolve_role_models_queries_once(monkeypatch):
         resolved = resolve_role_models()
     assert resolved == {AgentRole.CODER: DEEPSEEK, AgentRole.REVIEWER: QWEN}
     assert len(calls) == 1
+
+
+# -- registry_model (fine-tuning registry integration) -------------------
+
+
+FINETUNED = "deepseek-coder-finetuned:v2"
+
+
+def test_select_model_prefers_registry_over_family(monkeypatch):
+    """Registry-deployed model beats family-based discovery."""
+    # When the fine-tuned model is NOT installed, family discovery still works.
+    assert select_model(AgentRole.CODER, [DEEPSEEK, QWEN], registry_model=FINETUNED) == DEEPSEEK
+    # When the fine-tuned model is installed, it wins over family.
+    assert (
+        select_model(AgentRole.CODER, [DEEPSEEK, QWEN, FINETUNED], registry_model=FINETUNED)
+        == FINETUNED
+    )
+
+
+def test_select_model_registry_substring_match(monkeypatch):
+    """Registry model matches by substring against installed tags."""
+    installed_tag = "deepseek-coder-finetuned:v2-quantized"
+    assert (
+        select_model(AgentRole.CODER, [DEEPSEEK, installed_tag], registry_model=FINETUNED)
+        == installed_tag
+    )
+
+
+def test_select_model_override_beats_registry(monkeypatch):
+    """Explicit override still takes priority over registry model."""
+    assert (
+        select_model(
+            AgentRole.CODER,
+            [DEEPSEEK, QWEN, FINETUNED],
+            override=QWEN,
+            registry_model=FINETUNED,
+        )
+        == QWEN
+    )
+
+
+def test_select_model_env_override_beats_registry(monkeypatch):
+    """Environment override still takes priority over registry model."""
+    monkeypatch.setenv("EVOSEAL_CODER_MODEL", QWEN)
+    assert (
+        select_model(AgentRole.CODER, [DEEPSEEK, QWEN, FINETUNED], registry_model=FINETUNED) == QWEN
+    )
+
+
+def test_select_model_registry_not_installed_falls_through(monkeypatch):
+    """When the registry model is not installed, family discovery runs."""
+    assert (
+        select_model(AgentRole.CODER, [DEEPSEEK, QWEN], registry_model="not-installed:latest")
+        == DEEPSEEK
+    )
+
+
+def test_resolve_model_uses_registry_model(monkeypatch):
+    """resolve_model threads registry_model through to select_model."""
+    with _fake_ollama(monkeypatch, [DEEPSEEK, QWEN, FINETUNED]):
+        assert resolve_model(AgentRole.CODER, registry_model=FINETUNED) == FINETUNED
+
+
+def test_resolve_role_models_threads_registry(monkeypatch):
+    """resolve_role_models passes per-role registry models."""
+    with _fake_ollama(monkeypatch, [DEEPSEEK, QWEN, FINETUNED]):
+        resolved = resolve_role_models(registry_models={AgentRole.CODER: FINETUNED})
+    assert resolved == {AgentRole.CODER: FINETUNED, AgentRole.REVIEWER: QWEN}

--- a/tests/unit/providers/test_local_models.py
+++ b/tests/unit/providers/test_local_models.py
@@ -234,6 +234,20 @@ def test_select_model_registry_substring_match():
     )
 
 
+def test_select_model_registry_exact_beats_substring():
+    """An exact tag match is preferred over a substring match that appears earlier."""
+    stale_tag = "deepseek-coder-finetuned:v2-old"
+    exact_tag = "deepseek-coder-finetuned:v2"
+    # stale (substring) match appears first — exact match must still win.
+    assert (
+        select_model(AgentRole.CODER, [stale_tag, exact_tag], registry_model=FINETUNED) == exact_tag
+    )
+    # exact match appears first — still works.
+    assert (
+        select_model(AgentRole.CODER, [exact_tag, stale_tag], registry_model=FINETUNED) == exact_tag
+    )
+
+
 def test_select_model_override_beats_registry():
     """Explicit override still takes priority over registry model."""
     assert (

--- a/tests/unit/providers/test_local_models.py
+++ b/tests/unit/providers/test_local_models.py
@@ -214,7 +214,7 @@ def test_resolve_role_models_queries_once(monkeypatch):
 FINETUNED = "deepseek-coder-finetuned:v2"
 
 
-def test_select_model_prefers_registry_over_family(monkeypatch):
+def test_select_model_prefers_registry_over_family():
     """Registry-deployed model beats family-based discovery."""
     # When the fine-tuned model is NOT installed, family discovery still works.
     assert select_model(AgentRole.CODER, [DEEPSEEK, QWEN], registry_model=FINETUNED) == DEEPSEEK
@@ -225,7 +225,7 @@ def test_select_model_prefers_registry_over_family(monkeypatch):
     )
 
 
-def test_select_model_registry_substring_match(monkeypatch):
+def test_select_model_registry_substring_match():
     """Registry model matches by substring against installed tags."""
     installed_tag = "deepseek-coder-finetuned:v2-quantized"
     assert (
@@ -234,7 +234,7 @@ def test_select_model_registry_substring_match(monkeypatch):
     )
 
 
-def test_select_model_override_beats_registry(monkeypatch):
+def test_select_model_override_beats_registry():
     """Explicit override still takes priority over registry model."""
     assert (
         select_model(
@@ -255,10 +255,20 @@ def test_select_model_env_override_beats_registry(monkeypatch):
     )
 
 
-def test_select_model_registry_not_installed_falls_through(monkeypatch):
+def test_select_model_registry_not_installed_falls_through():
     """When the registry model is not installed, family discovery runs."""
     assert (
         select_model(AgentRole.CODER, [DEEPSEEK, QWEN], registry_model="not-installed:latest")
+        == DEEPSEEK
+    )
+
+
+def test_select_model_registry_rejects_wrong_role():
+    """Registry model matching a tag outside the role's families is skipped."""
+    embedding_tag = "nomic-embed-text:latest"
+    # The tag exists but is not a CODER-family model — must not be returned.
+    assert (
+        select_model(AgentRole.CODER, [DEEPSEEK, embedding_tag], registry_model=embedding_tag)
         == DEEPSEEK
     )
 


### PR DESCRIPTION
## What

`resolve_model` now accepts an optional `registry_model` parameter — the Ollama tag of the currently deployed fine-tuned model from `ModelVersionManager`. When provided and installed, the registry model is preferred over raw family-based discovery.

Resolution order is now:
1. Explicit override (`override=`)
2. Environment override (`EVOSEAL_CODER_MODEL` / `EVOSEAL_REVIEWER_MODEL`)
3. **Fine-tuning registry** (`registry_model=`) ← NEW
4. Family-based discovery (deepseek-coder, qwen2.5-coder, etc.)
5. Fallback tag

Wired through:
- `select_model` / `resolve_model` / `resolve_role_models` in `local_models.py`
- `OllamaProvider.__init__` (new `registry_model` kwarg)
- `CoevolutionManager.__init__` (threads `registry_model` to coder provider)

## Why

Addresses TODO.md P2 item 5: the generator only read raw installed Ollama tags and never consulted the fine-tuning registry, so a deployed fine-tuned model was never actually used for generation. This is the key wiring that closes the bidirectional co-evolution loop.

## Verification

- `ruff format --check .` ✅
- `ruff check evoseal/ tests/` ✅
- `pytest tests/unit/providers/test_local_models.py` — 31/31 passed ✅
- `pytest tests/` — 505 passed ✅ (full suite, pre-commit hooks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for preferring installed fine-tuned models from the local version registry during model resolution.
  - Enabled per-role registry fine-tuned model selection for both resolution and co-evolution manager startup.
  - Updated the Ollama-backed provider to prefer the registry-selected fine-tuned model when available.

- **Bug Fixes**
  - Improved graceful fallback to existing role-based discovery when the registry model is missing, incompatible, or cannot be read.

- **Tests**
  - Added unit tests covering registry matching behavior, per-role routing, precedence vs overrides, and error/fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->