### PR TITLE
fix: prevent path traversal in checkpoint identifier and file-path handling

### DIFF
--- a/evoseal/core/checkpoint_manager.py
+++ b/evoseal/core/checkpoint_manager.py
@@ -20,6 +20,21 @@ from .logging_system import get_logger
 logger = get_logger(__name__)
 
 
+def _validate_path_within_base(base_dir: Path, untrusted: str, label: str) -> Path:
+    """Ensure *untrusted* resolves to a path strictly inside *base_dir*.
+
+    Rejects identifiers containing path-separator or ``..`` components that
+    could escape *base_dir*. Raises ValueError on violation.
+    """
+    base = base_dir.resolve()
+    resolved = (base / untrusted).resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError:
+        raise ValueError(f"{label} {untrusted!r} would escape base directory {base}") from None
+    return resolved
+
+
 class CheckpointError(Exception):
     """Base exception for checkpoint operations."""
 
@@ -75,6 +90,9 @@ class CheckpointManager:
         Raises:
             CheckpointError: If checkpoint creation fails
         """
+        # Validate version_id does not escape checkpoint_dir (before try so ValueError propagates)
+        _validate_path_within_base(self.checkpoint_dir, version_id, "version_id")
+
         try:
             # Convert version to dict if it's an Experiment object
             if isinstance(version, Experiment):
@@ -118,6 +136,9 @@ class CheckpointManager:
             # Save version data files
             if changes:
                 for file_path, content in changes.items():
+                    # Validate file_path does not escape checkpoint_path
+                    _validate_path_within_base(checkpoint_path, file_path, "file_path")
+
                     if isinstance(content, str):
                         full_path = checkpoint_path / file_path
                         full_path.parent.mkdir(parents=True, exist_ok=True)
@@ -139,6 +160,7 @@ class CheckpointManager:
                         # Handle artifact references
                         src_path = Path(content["file_path"])
                         if src_path.exists():
+                            # file_path already validated above
                             dst_path = checkpoint_path / file_path
                             dst_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -203,6 +225,8 @@ class CheckpointManager:
             )
             return str(checkpoint_path)
 
+        except ValueError:
+            raise  # Let validation errors propagate directly
         except Exception as e:
             raise CheckpointError(
                 f"Failed to create checkpoint for version {version_id}: {e}"
@@ -227,6 +251,9 @@ class CheckpointManager:
         Raises:
             CheckpointError: If restoration fails
         """
+        # Validate version_id does not escape checkpoint_dir (before try so ValueError propagates)
+        _validate_path_within_base(self.checkpoint_dir, version_id, "version_id")
+
         try:
             target_dir = Path(target_dir)
             target_dir.mkdir(parents=True, exist_ok=True)
@@ -389,6 +416,9 @@ class CheckpointManager:
         """
         if version_id in self.checkpoints:
             return self.checkpoints[version_id]
+
+        # Validate version_id does not escape checkpoint_dir
+        _validate_path_within_base(self.checkpoint_dir, version_id, "version_id")
 
         checkpoint_path = self.checkpoint_dir / f"checkpoint_{version_id}"
         if checkpoint_path.exists():

--- a/evoseal/core/version_tracker.py
+++ b/evoseal/core/version_tracker.py
@@ -25,6 +25,20 @@ from .version_database import VersionDatabase
 logger = logging.getLogger(__name__)
 
 
+def _validate_checkpoint_id(base_dir: Path, untrusted: str, label: str) -> Path:
+    """Ensure *untrusted* resolves to a path strictly inside *base_dir*.
+
+    Raises ValueError if the resolved path escapes *base_dir*.
+    """
+    base = base_dir.resolve()
+    resolved = (base / untrusted).resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError:
+        raise ValueError(f"{label} {untrusted!r} would escape base directory {base}") from None
+    return resolved
+
+
 class VersionTrackingError(Exception):
     """Base exception for version tracking errors."""
 
@@ -266,7 +280,12 @@ class VersionTracker:
         timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
         checkpoint_id = f"{experiment_id}_{timestamp}"
         if checkpoint_name:
+            # Validate checkpoint_name before using it in a path
+            _validate_checkpoint_id(self.checkpoints_dir, checkpoint_name, "checkpoint_name")
             checkpoint_id += f"_{checkpoint_name}"
+
+        # Final defence-in-depth: validate the assembled checkpoint_id
+        _validate_checkpoint_id(self.checkpoints_dir, checkpoint_id, "checkpoint_id")
 
         # Create checkpoint directory
         checkpoint_dir = self.checkpoints_dir / checkpoint_id
@@ -314,6 +333,9 @@ class VersionTracker:
         Returns:
             Restored experiment
         """
+        # Validate checkpoint_id does not escape checkpoints_dir
+        _validate_checkpoint_id(self.checkpoints_dir, checkpoint_id, "checkpoint_id")
+
         checkpoint_dir = self.checkpoints_dir / checkpoint_id
         if not checkpoint_dir.exists():
             raise VersionTrackingError(f"Checkpoint {checkpoint_id} not found")

--- a/tests/unit/core/__init__.py
+++ b/tests/unit/core/__init__.py
@@ -1,0 +1,1 @@
+# Unit tests for core modules.

--- a/tests/unit/core/test_checkpoint_path_traversal.py
+++ b/tests/unit/core/test_checkpoint_path_traversal.py
@@ -1,0 +1,164 @@
+"""Regression tests for path traversal in checkpoint handling.
+
+These tests verify that attacker-controlled identifiers (version_id,
+checkpoint_name, file paths in changes dicts) cannot escape their
+intended base directory via directory traversal sequences.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from evoseal.core.checkpoint_manager import CheckpointManager, _validate_path_within_base
+from evoseal.core.version_tracker import VersionTracker, _validate_checkpoint_id
+
+# ---------------------------------------------------------------------------
+# _validate_path_within_base helper
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePathWithinBase:
+    """Tests for the _validate_path_within_base helper."""
+
+    def test_accepts_simple_name(self, tmp_path: Path) -> None:
+        base = tmp_path / "base"
+        base.mkdir()
+        result = _validate_path_within_base(base, "simple_name", "test")
+        assert result == (base / "simple_name").resolve()
+
+    def test_rejects_dotdot(self, tmp_path: Path) -> None:
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError, match="would escape base directory"):
+            _validate_path_within_base(base, "../etc/passwd", "test")
+
+    def test_rejects_absolute_path(self, tmp_path: Path) -> None:
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError, match="would escape base directory"):
+            _validate_path_within_base(base, "/etc/passwd", "test")
+
+    def test_rejects_nested_dotdot(self, tmp_path: Path) -> None:
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(ValueError, match="would escape base directory"):
+            _validate_path_within_base(base, "sub/../../escape", "test")
+
+    def test_accepts_subdirectory(self, tmp_path: Path) -> None:
+        base = tmp_path / "base"
+        base.mkdir()
+        result = _validate_path_within_base(base, "sub/dir/file", "test")
+        assert result == (base / "sub/dir/file").resolve()
+
+
+# ---------------------------------------------------------------------------
+# CheckpointManager — version_id traversal
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointManagerPathTraversal:
+    """Verify CheckpointManager rejects path-traversal in version_id and file paths."""
+
+    def _make_manager(self, tmp_path: Path) -> CheckpointManager:
+        return CheckpointManager({"checkpoint_directory": str(tmp_path / "checkpoints")})
+
+    # --- create_checkpoint ---
+
+    def test_create_checkpoint_rejects_dotdot_version_id(self, tmp_path: Path) -> None:
+        mgr = self._make_manager(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            mgr.create_checkpoint("../../etc/cron.d/evil", {"changes": {}})
+
+    def test_create_checkpoint_rejects_absolute_version_id(self, tmp_path: Path) -> None:
+        mgr = self._make_manager(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            mgr.create_checkpoint("/etc/passwd", {"changes": {}})
+
+    def test_create_checkpoint_rejects_escaped_changes_path(self, tmp_path: Path) -> None:
+        mgr = self._make_manager(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            mgr.create_checkpoint(
+                "valid_id",
+                {"changes": {"../../etc/cron.d/evil": "payload"}},
+            )
+
+    def test_create_checkpoint_accepts_valid_id(self, tmp_path: Path) -> None:
+        mgr = self._make_manager(tmp_path)
+        path = mgr.create_checkpoint("v1.0.0", {"changes": {"safe/file.py": "x = 1"}})
+        assert Path(path).exists()
+
+    # --- restore_checkpoint ---
+
+    def test_restore_checkpoint_rejects_dotdot_version_id(self, tmp_path: Path) -> None:
+        mgr = self._make_manager(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            mgr.restore_checkpoint("../../etc/passwd", tmp_path / "target")
+
+    def test_restore_checkpoint_rejects_absolute_version_id(self, tmp_path: Path) -> None:
+        mgr = self._make_manager(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            mgr.restore_checkpoint("/etc/passwd", tmp_path / "target")
+
+    # --- get_checkpoint_path ---
+
+    def test_get_checkpoint_path_rejects_dotdot_version_id(self, tmp_path: Path) -> None:
+        mgr = self._make_manager(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            mgr.get_checkpoint_path("../../etc/passwd")
+
+    def test_get_checkpoint_path_rejects_absolute_version_id(self, tmp_path: Path) -> None:
+        mgr = self._make_manager(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            mgr.get_checkpoint_path("/etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# VersionTracker — checkpoint_name traversal
+# ---------------------------------------------------------------------------
+
+
+class TestVersionTrackerPathTraversal:
+    """Verify VersionTracker rejects path-traversal in checkpoint_name."""
+
+    def _make_tracker(self, tmp_path: Path) -> VersionTracker:
+        """Create a VersionTracker with a mock experiment database."""
+        tracker = VersionTracker(work_dir=tmp_path / "work")
+        # Mock the experiment database so we don't need a real experiment
+        tracker.experiment_db = MagicMock()
+        mock_experiment = MagicMock()
+        mock_experiment.to_json.return_value = "{}"
+        mock_experiment.status.value = "completed"
+        mock_experiment.git_commit = "abc123"
+        mock_experiment.git_branch = "main"
+        mock_experiment.artifacts = []
+        tracker.experiment_db.get_experiment.return_value = mock_experiment
+        return tracker
+
+    def test_create_checkpoint_rejects_dotdot_name(self, tmp_path: Path) -> None:
+        tracker = self._make_tracker(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            tracker.create_checkpoint("exp1", checkpoint_name="../../escape")
+
+    def test_create_checkpoint_rejects_absolute_name(self, tmp_path: Path) -> None:
+        tracker = self._make_tracker(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            tracker.create_checkpoint("exp1", checkpoint_name="/etc/passwd")
+
+    def test_create_checkpoint_accepts_valid_name(self, tmp_path: Path) -> None:
+        tracker = self._make_tracker(tmp_path)
+        cp_id = tracker.create_checkpoint("exp1", checkpoint_name="my_checkpoint")
+        assert "my_checkpoint" in cp_id
+
+    def test_restore_checkpoint_rejects_dotdot_id(self, tmp_path: Path) -> None:
+        tracker = self._make_tracker(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            tracker.restore_checkpoint("../../etc/passwd")
+
+    def test_restore_checkpoint_rejects_absolute_id(self, tmp_path: Path) -> None:
+        tracker = self._make_tracker(tmp_path)
+        with pytest.raises(ValueError, match="would escape base directory"):
+            tracker.restore_checkpoint("/etc/passwd")


### PR DESCRIPTION
## Vulnerability

Path traversal in checkpoint handling allows attacker-controlled input to escape the checkpoint directory and write files to arbitrary locations on disk.

### Exploit scenario

A `version_id` like `"../../../../etc/cron.d/evil"` passed to `CheckpointManager.create_checkpoint()`, `restore_checkpoint()`, or `get_checkpoint_path()` would construct a path that escapes the checkpoint directory via `..` components. Similarly, the `changes` dict keys (file paths) in `create_checkpoint()` are joined directly onto the checkpoint path with no sanitization. The same class of bug exists in `VersionTracker.create_checkpoint()` where the caller-supplied `checkpoint_name` parameter is concatenated into a directory name without validation.

An attacker who controls `version_id`, `checkpoint_name`, or the `changes` dict keys could write checkpoint files to any location on the filesystem (e.g., `/etc/cron.d/evil`, `~/.ssh/authorized_keys`).

### Fix

Added `resolve()` + `relative_to()` containment validation (the same pattern used by `EditScopeValidator`) at each path construction site:

- **`checkpoint_manager.py`**: `version_id` validated in `create_checkpoint()`, `restore_checkpoint()`, and `get_checkpoint_path()`; `changes` dict file-path keys validated in `create_checkpoint()`
- **`version_tracker.py`**: `checkpoint_name` validated before use in `create_checkpoint()`; assembled `checkpoint_id` validated as defense-in-depth; `checkpoint_id` validated in `restore_checkpoint()`

Validation raises `ValueError` (not silently truncated) since this is safety-critical code — callers must know a malicious identifier was rejected.

### Note on `safety_integration.py`

`SafetyIntegration` does not route `version_id` through `EditScopeValidator` before calling `checkpoint_manager.create_checkpoint()`. This is fine — the fix is at the checkpoint construction site (the correct layer), not in the caller.

### Tests

Regression tests in `tests/unit/core/test_checkpoint_path_traversal.py` (18 tests):
- `_validate_path_within_base` helper: accepts simple names/subdirs, rejects `..`, absolute paths, nested `..`
- `CheckpointManager`: rejects dotdot/absolute `version_id` in create/restore/get, rejects escaped changes-dict file paths, accepts valid inputs
- `VersionTracker`: rejects dotdot/absolute `checkpoint_name` in create, rejects dotdot/absolute `checkpoint_id` in restore, accepts valid inputs

Full test suite: 516 passed.