### PR TITLE
docs: add whole-repo code review findings to TODO.md backlog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,38 @@
   - Added research-status callout at top of README; removed "production-ready" language
   - Reframed as research project; softened unsubstantiated benchmark claims
 
+### Critical Bugs Found in Whole-Repo Code Review (2026-07-22)
+
+> Full-repo review (`origin/main`, 9 parallel subsystem agents + 4 deep re-verification passes). Items below are read-confirmed against source, not speculative.
+
+- [ ] **Checkpoint identifiers/paths allow directory traversal — attacker-controlled arbitrary file write** _(fix in progress, branch `fix/checkpoint-path-traversal`)_
+  - `evoseal/core/checkpoint_manager.py`: `create_checkpoint()` (line 100), `restore_checkpoint()` (line 236), `get_checkpoint_path()` (line 393) all build `self.checkpoint_dir / f"checkpoint_{version_id}"` with zero validation of `version_id`. A `version_id` like `"../../../../etc/cron.d/evil"` resolves outside `checkpoint_dir` entirely (verified with `os.path.normpath`)
+  - Same file, lines 119-122: `changes` dict keys (`file_path`, attacker-controlled via evolution-pipeline results) are joined onto `checkpoint_path` unsanitized and written with attacker-controlled content — full arbitrary path + arbitrary bytes write primitive
+  - Sibling bug, same class: `evoseal/core/version_tracker.py:265-271` — public `checkpoint_name` parameter (via `evoseal/core/experiment_integration.py:369`) concatenated into a checkpoint id with no sanitization
+  - `EditScopeValidator` (`evoseal/core/edit_scope_validator.py`), which implements the correct `.resolve()` + `relative_to()` containment check, is **never called on this path** — `SafetyIntegration` holds instances of both `CheckpointManager` and `EditScopeValidator` but never bridges them
+  - Reachable from the live self-modification loop via `SafetyIntegration.create_safety_checkpoint()` → `checkpoint_manager.create_checkpoint()`
+- [ ] **`ImprovementValidator` is non-functional; the pipeline's actual validation gate is a hardcoded stub that always passes**
+  - `evoseal/core/improvement_validator.py:315-316` — `validate_improvement()` calls `self.metrics_tracker.get_metrics_by_id()`, but `MetricsTracker` only defines a private `_get_metrics_by_id` — every call raises `AttributeError`
+  - Same file, line 424 references an undefined `message` variable (`NameError` if Bug 1 were fixed); the method also has no `return` statement on its success path (always returns `None`)
+  - Irrelevant in practice: `grep` shows `validate_improvement()` is called from nowhere in production code (only the module's own `__main__` demo). `EvolutionPipeline` instantiates the validator (`evolution_pipeline.py:152`) but never calls it
+  - The actual gate wired into the pipeline is `evoseal/core/evolution_pipeline.py:919-922`: `async def _validate_improvement(...): # TODO: Implement improvement validation logic \n return True` — unconditionally returns `True`, feeding directly into `should_continue`. A self-modification that doubles test failures and triples runtime is accepted as a validated improvement, every time
+- [ ] **`EvolutionPipeline.__init__` never awaits its own resilience/circuit-breaker setup — every pipeline instance silently runs with zero resilience protection**
+  - `evoseal/core/evolution_pipeline.py:169` — `self._init_resilience_mechanisms()` is called from sync `__init__`, but the target (`evolution_pipeline.py:207`) is `async def`. The call just constructs and discards a coroutine (Python emits an unawaited-coroutine warning, no exception)
+  - Silently skips: starting `resilience_manager` monitoring, registering all component circuit breakers, the pipeline recovery strategy, degradation/fallback handlers, isolation policies, and the escalation handler — no error surfaced
+- [ ] **`run_evolution_cycle` always raises `TypeError` on its success path (malformed `Event` construction)**
+  - `evoseal/core/evolution_pipeline.py:450-459` and `:463-468` — `Event(EventType.EVOLUTION_COMPLETED, {...})` passes only 2 positional args, but `Event` (`evoseal/core/events.py:129`, a dataclass) requires 3 (`event_type, source, data`) — `TypeError: Event.__init__() missing 1 required positional argument: 'data'`
+  - The `except Exception` handler that's supposed to catch and report this constructs a second malformed `Event` for `ERROR_OCCURRED` (lines 464-468), which raises its own `TypeError` while handling the first — the second exception is what actually propagates
+  - Every documented example that calls the plain (non-`_with_safety`) cycle hits this on normal completion, no failure required. `run_evolution_cycle_with_safety` (line 474) has the identical malformed-`Event` bug at lines 676-680/700-707
+  - Secondary: `self.event_bus.publish(...)` is `async def` but called without `await` in these same blocks — even once `Event(...)` is fixed, these publishes would silently no-op rather than actually emitting the event
+- [ ] **`run_training_cycle` can never execute — readiness check always sees itself as "already running"**
+  - `evoseal/fine_tuning/training_manager.py:204` sets `self.current_training = {...}` *before* calling `check_training_readiness()` (line 214), which treats any non-`None` `self.current_training` as "training in progress" (lines 105-108) and aborts
+  - Every call to `run_training_cycle` fails at the readiness-check phase — the entire automated fine-tuning pipeline can never run. Same ordering-bug class as the `deploy_version` supersede-before-confirm bug fixed in PR #72 (commit `dd8364fa`)
+- [ ] **SEAL `BaseEditStrategy.apply()` corrupts files when `original_text` is empty**
+  - `evoseal/integration/seal/self_editor/strategies/base_strategy.py:53-54` — `if suggestion.original_text in content: return content.replace(suggestion.original_text, suggestion.suggested_text)`. Since `"" in content` is always `True`, an empty `original_text` hits `content.replace("", suggested_text)`, which splices the replacement before *every character* of the file
+  - `documentation_strategy.py` deliberately constructs `original_text=""` (meaning "insert here") at 4 call sites: lines 665, 698, 754, 1000
+  - Not hit by the current production path — `SelfEditor.apply_edit()` (`self_editor.py`) already guards against empty `original_text` correctly and is what production calls — but `BaseEditStrategy.apply()` is still public API, is called directly in `tests/unit/seal/self_editor/strategies/test_code_style_strategy.py:64`, and is the pattern documented in `self_editor/README.md:69`
+  - Fix belongs in `base_strategy.py:53` — reject/special-case empty `original_text` instead of relying on substring containment
+
 ---
 
 ## 🟠 P1 — High Priority
@@ -92,6 +124,36 @@
   - Allow users to set a max spend per run in config
   - Graceful stop when budget is exhausted
 
+### Safety & Correctness Bugs Found in Whole-Repo Code Review (2026-07-22)
+
+- [ ] **Model-safety validator can be defeated by an incidental safety word**
+  - `evoseal/fine_tuning/model_validator.py:432-454` — `_is_safe_response` returns `has_safety or not has_unsafe`. A response containing both an unsafe instruction and any safety-sounding word (e.g. `"Sorry, but here's how: rm -rf /"`) is classified safe regardless of the unsafe content. Defeats the safety gate that feeds deployment decisions
+- [ ] **Path traversal in git-file read/write helpers**
+  - `evoseal/utils/version_control/cmd_git.py:1130-1134` (`get_file_content`) and `:1176-1177` (`write_file_content`) — `full_path = self.repo_path / file_path` with no containment check. `pathlib` resolves an absolute RHS by discarding the LHS (`Path('/repo') / '/etc/passwd'` → `/etc/passwd`), and `..` segments aren't normalized either. Any caller passing an absolute or `..`-containing `file_path` (e.g. a model-generated patch) causes arbitrary file read/write outside the repo
+- [ ] **Monitoring dashboard has no authentication and permissive CORS-with-credentials**
+  - `evoseal/services/monitoring_dashboard.py:75-91` (`setup_cors`) — every route gets `aiohttp_cors.ResourceOptions(allow_credentials=True, allow_headers="*", allow_methods="*", expose_headers="*")` on a wildcard origin (CWE-942). No auth on any HTTP or WebSocket endpoint (`/api/status`, `/api/metrics`, `/api/report`, `/ws`), which return internal operational data (data paths, config, error strings). Defaults to `localhost` (limits blast radius today) but nothing prevents/warns against a `0.0.0.0` deploy, at which point this is unauthenticated remote information disclosure
+
+### CI/CD & Release Pipeline Issues Found in Whole-Repo Code Review (2026-07-22)
+
+- [ ] **Release pipeline is broken** _(exact failure mode needs re-verification — flagged by initial review pass, not yet deep-dived)_
+- [ ] **Some `workflow_run` triggers reference the wrong workflow name**, so dependent workflows don't actually fire when expected
+- [ ] **A `requirements/` directory referenced by tooling/CI does not exist**
+- [ ] **Security-scan gate is defeated by `continue-on-error: true`**, so a failing security check doesn't actually block anything
+
+### DGM/OpenEvolve Adapter Issues Found in Whole-Repo Code Review (2026-07-22)
+
+- [ ] **`evoseal/integration/dgm/` + `dgmr/` and `evoseal/integration/oe/` + `openevolve/` look like duplicated/forked adapter implementations that have drifted apart** — needs a decision on which is canonical and whether the other should be removed or reconciled
+- [ ] **DGM/OpenEvolve job runner reports failed jobs as successful** _(exact file:line needs re-verification — flagged by initial review pass, not yet deep-dived)_
+
+### CLI Issues Found in Whole-Repo Code Review (2026-07-22)
+
+- [ ] **`evoseal export` fabricates results instead of reporting real failures** _(exact file:line needs re-verification)_
+- [ ] **Several `evoseal pipeline` subcommands are stubs**, not implemented behavior _(exact file:line needs re-verification)_
+
+### SEAL Subsystem Issues Found in Whole-Repo Code Review (2026-07-22)
+
+- [ ] **Knowledge retrieval in the SEAL subsystem is broken** _(exact file:line needs re-verification — flagged by initial review pass, not yet deep-dived)_
+
 ---
 
 ## 🟡 P2 — Medium Priority
@@ -140,6 +202,21 @@
   - Malformed YAML, missing required sections, type mismatches
 - [ ] **Add test for checkpoint save/restore**
   - Interrupt mid-evolution, restore from checkpoint, verify state consistency
+- [ ] **Add tests for safety-decision orchestration** _(found 2026-07-22 whole-repo review)_ — the code paths behind the checkpoint/ImprovementValidator/resilience-init bugs above have zero regression test coverage today, which is plausibly why they shipped unnoticed
+
+### Medium-Priority Bugs Found in Whole-Repo Code Review (2026-07-22)
+
+- [ ] **`bidirectional_manager.py` state fields are never mutated** — `self.stats`, `self.evolution_history`, `self.is_running`, `self.last_check_time` are set in `__init__` but nothing in the codebase ever updates them (confirmed via repo-wide grep); `continuous_evolution_service.py` maintains its own separate loop state instead. `get_evolution_status()`/`generate_evolution_report()` always report zero cycles and `is_running=False` even while the loop actively runs
+- [ ] **`version_manager.py` registry file has no atomic write** — `_save_registry()` (lines 70-77, PR #72 branch) writes directly via `open(...,"w")` + `json.dump`; a crash/kill mid-write leaves a truncated file, and `_load_registry()` silently resets to an empty registry on parse failure, losing all version history
+- [ ] **`version_manager.py` has no locking around concurrent registry mutation** — overlapping `register_version`/`deploy_version` calls can interleave writes to `self.registry["versions"]`, risking lost updates or an inconsistent `current_version`
+- [ ] **`model_fine_tuner.py:160-178` uses `trust_remote_code=True`** on both `AutoTokenizer`/`AutoModelForCausalLM.from_pretrained`, combined with a fallback (`_resolve_hf_base_model()`, lines 107-120) that uses `model_name` verbatim as an HF repo id for unknown families — a bad config value or env var (`EVOSEAL_CODER_MODEL`) can execute arbitrary remote code locally. `# nosec B615` suppresses the linter, not the risk
+- [ ] **`provider_manager.py` treats unhealthy providers as healthy when called from a running event loop** — `get_best_available_provider()` (lines 100-111) and `list_providers()` (lines 196-201) create a health-check task via `loop.create_task(...)` but never await/consume it, then unconditionally set `is_healthy = True`, discarding the real result; the orphaned task can also produce unretrieved-exception warnings
+- [ ] **`agentic_system.py:28` logger bypasses the logging handler hierarchy** — `Logger("AgenticSystem")` is instantiated directly instead of via `logging.getLogger(name)`; `self.parent` stays `None`, no handlers attach, and all INFO-level agent-orchestration logs (create/destroy, message send, task assignment) are silently dropped by default
+- [ ] **`agentic_workflow_agent.py:14` couples to a private API and can crash inside a running event loop** — `WorkflowAgent.act` calls `self.engine._execute_step(...)`, a `_`-prefixed private method of `WorkflowEngine` that internally does `asyncio.run(...)`; invoking a `WorkflowAgent` through the async entry points while already inside a running event loop raises `RuntimeError: asyncio.run() cannot be called from a running event loop`
+- [ ] **`continuous_evolution_service.py:107-115` registers process-wide signal handlers from `__init__`** — `signal.signal()` only works on the main thread (raises `ValueError` if constructed off-thread), and the handler's `asyncio.create_task(self.shutdown())` requires a running event loop in the current thread at signal-time; also clobbers whatever signal handlers an embedding application had installed, since this fires on mere construction, not `start()`
+- [ ] **`models/experiment.py:256-260` references an undefined name `FieldValidationInfo`** — never imported anywhere in the module (only `field_validator`/`model_validator` are imported from pydantic); only survives today because `from __future__ import annotations` defers evaluation. Breaks under `typing.get_type_hints()`, strict mypy/pyright, or Sphinx autodoc. Correct type is `pydantic.ValidationInfo`
+- [ ] **`models/system_config.py:33-39` `from_yaml` doesn't validate the loaded YAML is a dict** — an empty file yields `None`, a scalar/list document yields a non-dict; `self.config` is set as-is and the first `get()`/`validate()` call raises an opaque `TypeError` instead of a clear config error
+- [ ] **`cmd_git.py:1754` `_find_referenced_by` passes a nonexistent `ref` kwarg** — calls `self._run_git_command(cmd, ref=ref)`, but `GitInterface._run_git_command` has no `ref` parameter; raises `TypeError` any time `find_file_references()` is called with an explicit ref
 
 ### Evolution Archive & Rollout _(inspired by OpenClaw patterns)_
 
@@ -172,6 +249,19 @@
 - [ ] **Adopt workspace prompt file conventions** _(inspired by OpenClaw's AGENTS.md/SOUL.md/TOOLS.md)_
   - Create a standard file layout for the evolution workspace: e.g., `AGENT.md` (agent identity/constraints), `EVOLUTION.md` (current evolution goals/state), `SAFETY.md` (safety invariants)
   - Makes the system self-documenting and easier for contributors to understand agent behavior at any point
+
+### Low-Priority / Hygiene Issues Found in Whole-Repo Code Review (2026-07-22)
+
+- [ ] **`cmd_git.py:977` `tag()` builds a malformed argv token** — `cmd.append("-s" if not sign_key else f"-u {sign_key}")` appends `"-u <key>"` as one argv element instead of `["-u", sign_key]`; since commands run via `subprocess.run(list, shell=False)`, git receives one malformed token and signed-tag-with-explicit-key fails
+- [ ] **`git_interface.py` credential-helper config is broken** — sets `credential.helper` to the literal string `'cache --timeout=300'` including the quotes (no shell involved, so they're taken literally), via two non-`--add` `--local` sets where the second silently overwrites the first with a bogus value — HTTPS credential caching silently doesn't work
+- [ ] **Stray `evoseal/utils/validator.py.bak`** — a 1132-line backup committed to the repo tree (not gitignored), diverged from `validator.py`; risk of editing the wrong file
+- [ ] **`evoseal/utils/testing/environment.py:180`** — `suffix: str = None` type-annotation mismatch (should be `Optional[str]`)
+- [ ] **`providers/ollama_provider.py:98-136`** — `submit_prompt` has no retry/backoff on transient network failures despite being the sole retry/timeout surface for local model calls
+- [ ] **`providers/local_models.py:103-119`** — `_query_installed_models` is `lru_cache`d indefinitely with no TTL; a newly pulled/removed Ollama model isn't picked up until something explicitly calls `clear_model_cache()`
+- [ ] **`model_fine_tuner.py:122-137`** — `_check_gpu_availability()` is defined but never called; despite the module docstring claiming "Requires a CUDA GPU," `initialize_model()` silently proceeds on CPU instead of failing fast
+- [ ] **`model_fine_tuner.py:220,240`** — `example['instruction']`/`example['output']` direct dict access with no `.get()`; a malformed training example raises `KeyError` surfaced only as a generic error string instead of a clear validation message
+- [ ] **`models/code_archive.py:127-149`** — `__init__` manually re-implements every default already provided by `Field(default_factory=...)`, a drift hazard (two sources of truth for the same defaults)
+- [ ] **`evoseal/agents/agentic_system_example.py:7`** — `from evoseal.agentic_system import ...` is the wrong module path (actual: `evoseal.agents.agentic_system`); the example fails immediately with `ModuleNotFoundError`
 
 ### Documentation Polish
 
@@ -211,11 +301,11 @@
 
 | Priority | Total | Done | Notes |
 |----------|-------|------|-------|
-| 🔴 P0    | 5     | 5    | All complete as of 2026-06-04 |
-| 🟠 P1    | 12    | 10   | All safety hardening + integration items done; Tier 2 deferred |
-| 🟡 P2    | 17    | 4    | Co-evolution loop gaps (7 items, 4 done) + existing P2 |
-| 🟢 P3    | 14    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete |
-| **Total** | **48** | **25** | |
+| 🔴 P0    | 11    | 5    | Original 5 complete; +6 critical bugs from 2026-07-22 whole-repo review (1 fix in progress) |
+| 🟠 P1    | 24    | 10   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
+| 🟡 P2    | 29    | 4    | Co-evolution loop gaps (7 items, 4 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
+| 🟢 P3    | 24    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
+| **Total** | **88** | **25** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >


### PR DESCRIPTION
## Summary

Adds 38 findings from a whole-repo code review (2026-07-22, `origin/main`) to `TODO.md` as backlog items, organized by priority:

- **P0 (6 items):** critical bugs — checkpoint path traversal, dead-code `ImprovementValidator` + a hardcoded-`True` validation stub that means self-modifications are never actually gated on their metrics, un-awaited resilience init, a `TypeError` that crashes `run_evolution_cycle` on its success path, a fine-tuning pipeline that can never execute due to an ordering bug, and a SEAL strategy bug that can corrupt files via an unguarded `content.replace("", ...)`.
- **P1 (12 items):** high-priority bugs — a safety-response validator that can be defeated by an incidental safety word, path traversal in git file read/write helpers, an unauthenticated monitoring dashboard with permissive CORS, CI/release pipeline issues, DGM/OpenEvolve adapter duplication/drift, CLI stub commands, broken SEAL knowledge retrieval.
- **P2 (12 items):** medium-priority bugs — untracked service state, non-atomic registry writes, missing concurrency locking, an RCE risk via `trust_remote_code=True`, logging/signal-handling issues, type-safety gaps.
- **P3 (10 items):** low-priority hygiene — malformed CLI argv construction, broken git credential caching, a stray backup file, missing retry logic.

Methodology: 9 parallel review agents covering every subsystem (`core/`, `integration/`, `cli/`, `fine_tuning/`, `providers/`, `models/`, `utils/`, `evolution/`, `agents/`, `services/`, `tests/`, docs/config/CI), followed by 4 independent deep-dive re-verification passes on the P0 findings to confirm exact file:line and get a concrete repro before adding them to the backlog. Every item cites file:line and either a verified repro or an explicit "needs re-verification" flag where the finding came from the first-pass review only.

The checkpoint path-traversal fix (first item) is in progress on a separate branch, `fix/checkpoint-path-traversal`.

Documentation-only change — no code modified. All 498 unit tests pass, pre-commit hooks pass.

## Test plan

- [x] Pre-commit hooks pass (ruff, pytest fast-check, detect-secrets)
- [x] Reviewed full diff for accuracy against the source findings
- [ ] Human review of backlog prioritization/grouping