### PR TITLE
fix: wire real improvement validation into evolution pipeline (was hardcoded True stub)

### DIFF
--- a/evoseal/core/evolution_pipeline.py
+++ b/evoseal/core/evolution_pipeline.py
@@ -917,9 +917,47 @@ class EvolutionPipeline:
         return {"metrics": {}}
 
     async def _validate_improvement(self, evaluation_result: dict[str, Any]) -> bool:
-        """Validate if the new version is an improvement."""
-        # TODO: Implement improvement validation logic
-        return True
+        """Validate if the new version is an improvement.
+
+        Uses the ImprovementValidator to compare the two most recent metric
+        entries.  When fewer than two entries exist (e.g. the very first
+        iteration) there is nothing to regress against, so we treat the
+        validation as passing — the first iteration is always accepted.
+
+        Any error *during* a validation that could run is treated as a
+        failure (fail-closed).
+        """
+        test_type = evaluation_result.get("test_type")
+        metrics = self.metrics_tracker.get_metrics_history(test_type)
+
+        # First iteration or no history yet — nothing to compare against.
+        if len(metrics) < 2:
+            logger.info(
+                "Improvement validation skipped: fewer than 2 metric entries "
+                "(first iteration or no metrics recorded yet)."
+            )
+            return True
+
+        # Compare the two most recent entries: index -2 (baseline) vs -1 (current).
+        baseline_id = len(metrics) - 2
+        comparison_id = len(metrics) - 1
+
+        try:
+            result = self.validator.validate_improvement(baseline_id, comparison_id, test_type)
+        except Exception:
+            logger.exception(
+                "Improvement validation failed with an exception — treating as NOT an improvement"
+            )
+            return False
+
+        is_improvement = bool(result.get("is_improvement", False))
+        logger.info(
+            "Improvement validation result: %s (score=%.1f, required_passed=%s)",
+            "PASS" if is_improvement else "FAIL",
+            result.get("score", 0.0),
+            result.get("required_passed"),
+        )
+        return is_improvement
 
     def _check_budget_before_iteration(
         self, iteration_num: int, results: list[dict[str, Any]]

--- a/evoseal/core/improvement_validator.py
+++ b/evoseal/core/improvement_validator.py
@@ -124,7 +124,7 @@ class ValidationRule:
             "is_valid": False,
             "improvement_pct": 0.0,
             "effect_size": None,
-            "is_significant": False,
+            "is_significant": None,
             "confidence_interval": None,
             "p_value": None,
             "meets_effect_size": True,
@@ -377,7 +377,7 @@ class ImprovementValidator:
             if rule.required and not rule_passed:
                 all_required_passed = False
 
-            if rule.required and not rule_result.get("is_significant", True):
+            if rule.required and rule_result.get("is_significant") is False:
                 has_statistical_significance = False
 
             # Prepare detailed result
@@ -416,11 +416,34 @@ class ImprovementValidator:
             and has_statistical_significance
         )
 
+        # Build a human-readable summary message
+        if is_improvement:
+            message = (
+                f"Improvement validated: score {overall_score:.1f}/100 "
+                f"(threshold {self.min_improvement_score:.1f})"
+            )
+        else:
+            reasons = []
+            if not all_required_passed:
+                reasons.append("required rules failed")
+            if overall_score < self.min_improvement_score:
+                reasons.append(
+                    f"score {overall_score:.1f} < threshold {self.min_improvement_score:.1f}"
+                )
+            if not has_statistical_significance:
+                reasons.append("lacks statistical significance")
+            message = (
+                f"Not an improvement: {', '.join(reasons)}" if reasons else "Not an improvement"
+            )
+
         # Prepare the final result
         validation_result = {
             "is_improvement": is_improvement,
             "score": overall_score,
             "required_passed": all_required_passed,
+            "meets_score_threshold": overall_score >= self.min_improvement_score,
+            "has_statistical_significance": has_statistical_significance,
+            "confidence_level": self.confidence_level,
             "message": message,
             "baseline_id": baseline_id,
             "comparison_id": comparison_id,
@@ -428,6 +451,7 @@ class ImprovementValidator:
             "details": results,
             "timestamp": datetime.utcnow().isoformat(),
         }
+        return validation_result
 
     def display_validation_results(self, validation_result: ValidationResult) -> None:
         """Display validation results in a formatted table.
@@ -459,7 +483,7 @@ class ImprovementValidator:
             change_str = f"{change_pct:+.1f}%"
 
             # Format status with color
-            if detail["is_valid"]:
+            if detail["passed"]:
                 status = "[green]PASS[/green]"
             elif not detail["required"]:
                 status = "[yellow]WARN[/yellow]"
@@ -470,8 +494,8 @@ class ImprovementValidator:
             table.add_row(
                 detail["rule"],
                 detail["metric"],
-                str(detail["baseline"]),
-                str(detail["current"]),
+                str(detail["baseline_value"]),
+                str(detail["current_value"]),
                 change_str,
                 status,
                 f"{detail['score']:.1f}",
@@ -604,7 +628,7 @@ class ImprovementValidator:
             "is_improvement": validation_result["is_improvement"],
             "score": validation_result["score"],
             "confidence_level": validation_result.get("confidence_level", 0.95),
-            "passed_required": validation_result["passed_required"],
+            "passed_required": validation_result["required_passed"],
             "has_statistical_significance": validation_result.get(
                 "has_statistical_significance", True
             ),

--- a/evoseal/core/metrics_tracker.py
+++ b/evoseal/core/metrics_tracker.py
@@ -440,10 +440,24 @@ class MetricsTracker:
             key=lambda x: x.timestamp,
         )
 
+    def get_metrics_by_id(
+        self, metric_id: int | str, test_type: str | None = None
+    ) -> TestMetrics | None:
+        """Get metrics by index or timestamp.
+
+        Args:
+            metric_id: Integer index (supports negative indexing) or timestamp prefix.
+            test_type: Optional test-type filter applied before resolving the id.
+
+        Returns:
+            The matching TestMetrics, or None if not found.
+        """
+        return self._get_metrics_by_id(metric_id, test_type)
+
     def _get_metrics_by_id(
         self, metric_id: int | str, test_type: str | None = None
     ) -> TestMetrics | None:
-        """Get metrics by index or timestamp."""
+        """Get metrics by index or timestamp (private implementation)."""
         metrics = self._filter_metrics_by_type(test_type)
 
         if not metrics:

--- a/tests/unit/core/test_improvement_validation.py
+++ b/tests/unit/core/test_improvement_validation.py
@@ -1,0 +1,166 @@
+"""Regression tests for improvement validation wiring.
+
+Verifies that:
+- A genuine improvement (better metrics) is accepted.
+- A regression (worse metrics) is rejected.
+- The plumbing between EvolutionPipeline, ImprovementValidator, and
+  MetricsTracker works without AttributeError / NameError.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from evoseal.core.improvement_validator import ImprovementValidator
+from evoseal.core.metrics_tracker import MetricsTracker, TestMetrics
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_metrics(
+    *,
+    test_type: str = "unit",
+    timestamp: str = "2026-01-01T00:00:00Z",
+    tests_passed: int = 10,
+    tests_failed: int = 0,
+    success_rate: float = 100.0,
+    duration_sec: float = 1.0,
+    memory_mb: float = 50.0,
+) -> TestMetrics:
+    return TestMetrics(
+        test_type=test_type,
+        timestamp=timestamp,
+        total_tests=tests_passed + tests_failed,
+        tests_passed=tests_passed,
+        tests_failed=tests_failed,
+        tests_skipped=0,
+        tests_errors=0,
+        success_rate=success_rate,
+        duration_sec=duration_sec,
+        memory_mb=memory_mb,
+    )
+
+
+def _tracker_with_history(metrics_list: list[TestMetrics]) -> MetricsTracker:
+    tracker = MetricsTracker()
+    tracker.metrics_history = list(metrics_list)
+    return tracker
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateImprovementPlumbing:
+    """Ensure validate_improvement runs without AttributeError / NameError."""
+
+    def test_returns_dict_with_required_keys(self):
+        """validate_improvement must return a dict containing all keys that
+        downstream consumers (save_validation_report, display, pipeline) rely
+        on — no AttributeError or NameError."""
+        tracker = _tracker_with_history(
+            [
+                _make_metrics(timestamp="2026-01-01T00:00:00Z", success_rate=80.0),
+                _make_metrics(timestamp="2026-01-02T00:00:00Z", success_rate=90.0),
+            ]
+        )
+        validator = ImprovementValidator(tracker, min_improvement_score=50.0)
+
+        result = validator.validate_improvement(0, 1, "unit")
+
+        # Core keys
+        assert "is_improvement" in result
+        assert "score" in result
+        assert "required_passed" in result
+        assert "meets_score_threshold" in result
+        assert "message" in result
+        assert isinstance(result["message"], str)
+        assert "details" in result
+        assert "timestamp" in result
+
+        # Per-detail keys used by display_validation_results
+        for detail in result["details"]:
+            assert "baseline_value" in detail, detail
+            assert "current_value" in detail, detail
+            assert "passed" in detail, detail
+            assert "improvement_pct" in detail, detail
+
+    def test_save_validation_report_reads_correct_keys(self):
+        """save_validation_report must not raise KeyError — verifies the
+        passed_required → required_passed mapping fix."""
+        tracker = _tracker_with_history(
+            [
+                _make_metrics(timestamp="2026-01-01T00:00:00Z"),
+                _make_metrics(timestamp="2026-01-02T00:00:00Z"),
+            ]
+        )
+        validator = ImprovementValidator(tracker, min_improvement_score=50.0)
+        result = validator.validate_improvement(0, 1, "unit")
+
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "report.json"
+            # Must not raise KeyError
+            validator.save_validation_report(result, out)
+            assert out.exists()
+
+
+class TestImprovementAccepted:
+    """Genuine improvement should be accepted."""
+
+    def test_improvement_returns_true(self):
+        """Better success rate + faster duration → is_improvement True."""
+        tracker = _tracker_with_history(
+            [
+                _make_metrics(
+                    timestamp="2026-01-01T00:00:00Z",
+                    tests_passed=7,
+                    tests_failed=3,
+                    success_rate=70.0,
+                    duration_sec=2.0,
+                ),
+                _make_metrics(
+                    timestamp="2026-01-02T00:00:00Z",
+                    tests_passed=10,
+                    tests_failed=0,
+                    success_rate=100.0,
+                    duration_sec=1.0,
+                ),
+            ]
+        )
+        validator = ImprovementValidator(tracker, min_improvement_score=50.0)
+        result = validator.validate_improvement(0, 1, "unit")
+        assert result["is_improvement"] is True
+
+
+class TestRegressionRejected:
+    """A regression should be rejected."""
+
+    def test_regression_returns_false(self):
+        """Worse success rate + more failures → is_improvement False."""
+        tracker = _tracker_with_history(
+            [
+                _make_metrics(
+                    timestamp="2026-01-01T00:00:00Z",
+                    tests_passed=10,
+                    tests_failed=0,
+                    success_rate=100.0,
+                    duration_sec=1.0,
+                ),
+                _make_metrics(
+                    timestamp="2026-01-02T00:00:00Z",
+                    tests_passed=5,
+                    tests_failed=5,
+                    success_rate=50.0,
+                    duration_sec=3.0,
+                ),
+            ]
+        )
+        validator = ImprovementValidator(tracker, min_improvement_score=50.0)
+        result = validator.validate_improvement(0, 1, "unit")
+        assert result["is_improvement"] is False


### PR DESCRIPTION
## Bug

`EvolutionPipeline._validate_improvement()` (line 919) was a hardcoded stub:

```python
async def _validate_improvement(self, evaluation_result):
    # TODO: Implement improvement validation logic
    return True
```

This fed into `should_continue` at line 830, meaning **every self-modification was accepted regardless of whether it regressed metrics**. A change that increases test failures or degrades performance would pass validation and be treated as an improvement.

Meanwhile, `ImprovementValidator` existed (instantiated at line 152) but was never called, and had multiple bugs that would have prevented it from working:

## Bugs fixed

### `improvement_validator.py`

| Bug | Impact |
|-----|--------|
| `validate_improvement()` called `self.metrics_tracker.get_metrics_by_id()` — method did not exist (only private `_get_metrics_by_id`) | **AttributeError** on every call |
| Undefined variable `message` on success path (line 424) | **NameError** after fixing bug 1 |
| Missing `return validation_result` — method returned `None` on success | Caller always got `None` |
| `save_validation_report()` read `validation_result["passed_required"]` but dict had `"required_passed"` | **KeyError** |
| `display_validation_results()` read `detail["baseline"]` / `detail["current"]` but per-rule dicts use `"baseline_value"` / `"current_value"` | **KeyError** |
| `display_validation_results()` read `detail["is_valid"]` but per-rule dicts use `"passed"` | **KeyError** |
| `ValidationRule.validate()` initialized `is_significant=False` even when no statistical test was run (`sample_size=1`) | "Untested" indistinguishable from "tested and failed" |
| `has_statistical_significance` check: `not rule_result.get("is_significant", True)` treated `None` (untested) same as `False` (tested and failed) | All validations rejected when t-test not applicable |

### `evolution_pipeline.py`

- Replaced the `return True` stub with a real call to `self.validator.validate_improvement()` using the two most recent metric entries from `self.metrics_tracker`
- First iteration (< 2 metric entries) passes by design — nothing to regress against
- Exceptions during validation are caught and treated as fail-closed (returns `False`, not `True`)

### `metrics_tracker.py`

- Added public `get_metrics_by_id()` method that delegates to the existing private `_get_metrics_by_id()` — matches the pattern of other public methods in the class

## Tests

Regression tests in `tests/unit/core/test_improvement_validation.py`:
- **Plumbing**: `validate_improvement()` returns a dict with all required keys (no AttributeError/NameError)
- **Plumbing**: `save_validation_report()` works without KeyError
- **Acceptance**: genuine improvement (better success rate + faster) → `is_improvement=True`
- **Rejection**: regression (worse success rate + more failures) → `is_improvement=False`

## Verification

Full test suite: 502 passed. Ruff format/check: clean.