### PR TITLE
fix: evolution_pipeline unawaited resilience init + TypeError-crashing run_evolution_cycle

### DIFF
--- a/evoseal/core/evolution_pipeline.py
+++ b/evoseal/core/evolution_pipeline.py
@@ -165,8 +165,9 @@ class EvolutionPipeline:
         # Initialize workflow engine
         self.workflow_engine = WorkflowEngine()
 
-        # Initialize resilience and error handling
-        self._init_resilience_mechanisms()
+        # Resilience mechanisms require an async event loop to start monitoring
+        # and are lazily initialized on first use (see _ensure_resilience_initialized).
+        self._resilience_initialized = False
 
         # Initialize component connectors
         self._init_component_connectors()
@@ -375,6 +376,18 @@ class EvolutionPipeline:
         self.event_bus.subscribe(EventType.STEP_STARTED, self._on_step_started)
         self.event_bus.subscribe(EventType.STEP_COMPLETED, self._on_step_completed)
 
+    async def _ensure_resilience_initialized(self) -> None:
+        """Lazily initialize resilience mechanisms on first async use.
+
+        Called at the start of each evolution cycle so that circuit breakers,
+        monitoring, recovery strategies, etc. are registered before any work
+        is attempted.  Safe to call multiple times — only the first call runs
+        the setup.
+        """
+        if not self._resilience_initialized:
+            await self._init_resilience_mechanisms()
+            self._resilience_initialized = True
+
     async def run_evolution_cycle(self, iterations: int = 1) -> list[dict[str, Any]]:
         """Run a complete evolution cycle.
 
@@ -384,6 +397,8 @@ class EvolutionPipeline:
         Returns:
             List of results from each iteration.
         """
+        await self._ensure_resilience_initialized()
+
         results = []
 
         try:
@@ -448,10 +463,11 @@ class EvolutionPipeline:
                 if not iteration_result["should_continue"]:
                     break
 
-            self.event_bus.publish(
+            await self.event_bus.publish(
                 Event(
-                    EventType.EVOLUTION_COMPLETED,
-                    {
+                    event_type=EventType.EVOLUTION_COMPLETED,
+                    source="evolution_pipeline",
+                    data={
                         "timestamp": datetime.utcnow().isoformat(),
                         "iterations_completed": len(results),
                         "successful_iterations": sum(1 for r in results if r["success"]),
@@ -461,10 +477,11 @@ class EvolutionPipeline:
 
         except Exception as e:
             logger.exception("Error during evolution cycle")
-            self.event_bus.publish(
+            await self.event_bus.publish(
                 Event(
-                    EventType.ERROR_OCCURRED,
-                    {"error": str(e), "timestamp": datetime.utcnow().isoformat()},
+                    event_type=EventType.ERROR_OCCURRED,
+                    source="evolution_pipeline",
+                    data={"error": str(e), "timestamp": datetime.utcnow().isoformat()},
                 )
             )
             raise
@@ -490,6 +507,8 @@ class EvolutionPipeline:
         Returns:
             List of results from each iteration with safety information
         """
+        await self._ensure_resilience_initialized()
+
         results = []
         current_version_id = None
 
@@ -675,8 +694,9 @@ class EvolutionPipeline:
             # Publish evolution completed event
             await event_bus.publish(
                 Event(
-                    EventType.EVOLUTION_COMPLETED,
-                    {
+                    event_type=EventType.EVOLUTION_COMPLETED,
+                    source="evolution_pipeline",
+                    data={
                         "timestamp": datetime.utcnow().isoformat(),
                         "iterations_completed": len(results),
                         "successful_iterations": sum(1 for r in results if r.get("success", False)),
@@ -701,8 +721,9 @@ class EvolutionPipeline:
             logger.exception("Error during safety-aware evolution cycle")
             await event_bus.publish(
                 Event(
-                    EventType.ERROR_OCCURRED,
-                    {
+                    event_type=EventType.ERROR_OCCURRED,
+                    source="evolution_pipeline",
+                    data={
                         "error": str(e),
                         "timestamp": datetime.utcnow().isoformat(),
                         "safety_enabled": True,

--- a/tests/unit/core/test_pipeline_init_and_events.py
+++ b/tests/unit/core/test_pipeline_init_and_events.py
@@ -1,0 +1,188 @@
+"""Regression tests for evolution_pipeline Bug 1 and Bug 2.
+
+Bug 1: _init_resilience_mechanisms was called without await from sync __init__,
+so resilience setup never ran.
+
+Bug 2: Event() constructed with 2 positional args instead of 3, raising
+TypeError on every successful run_evolution_cycle.  Also missing await on
+publish in run_evolution_cycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from evoseal.core.events import Event, EventType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_real_pipeline_module():
+    """Undo sys.modules poisoning from test_workflow_integration.py.
+
+    That test replaces evoseal.core.evolution_pipeline with a MagicMock at
+    import time.  We detect this and evict the poisoned entry so a fresh
+    import gets the real module.
+    """
+    mod = sys.modules.get("evoseal.core.evolution_pipeline")
+    if mod is not None and type(mod).__name__ == "MagicMock":
+        # Also evict sub-modules that may have been imported through the mock
+        for key in list(sys.modules):
+            if key.startswith("evoseal.core.evolution_pipeline"):
+                del sys.modules[key]
+
+
+def _make_pipeline():
+    """Build an EvolutionPipeline with heavy deps stubbed out."""
+    _ensure_real_pipeline_module()
+
+    with (
+        patch("evoseal.core.evolution_pipeline.Settings") as mock_settings_cls,
+        patch("evoseal.core.evolution_pipeline.SafetyIntegration"),
+        patch("evoseal.core.evolution_pipeline.SandboxedTestRunner"),
+        patch("evoseal.core.evolution_pipeline.ImprovementValidator"),
+        patch("evoseal.core.evolution_pipeline.MetricsTracker"),
+        patch("evoseal.core.evolution_pipeline.BudgetTracker"),
+        patch("evoseal.core.evolution_pipeline.IntegrationOrchestrator"),
+    ):
+        mock_settings = MagicMock()
+        mock_settings.budget.max_tokens_per_run = 1_000_000
+        mock_settings.budget.warn_at_percent_of_budget = 80
+        mock_settings.budget.cost_per_1k_tokens = 0.01
+        mock_settings_cls.return_value = mock_settings
+
+        from evoseal.core.evolution_pipeline import EvolutionPipeline
+
+        pipeline = EvolutionPipeline()
+        return pipeline
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — Event() construction + missing await
+# ---------------------------------------------------------------------------
+
+
+class TestRunEvolutionCycleEvents:
+    """run_evolution_cycle must not raise TypeError and must publish correct events."""
+
+    def test_completes_without_typeerror(self):
+        """A normal run_evolution_cycle must complete without TypeError."""
+        pipeline = _make_pipeline()
+        results = asyncio.run(pipeline.run_evolution_cycle(iterations=1))
+        assert isinstance(results, list)
+
+    def test_publishes_evolution_completed(self):
+        """run_evolution_cycle must publish EVOLUTION_COMPLETED with correct data."""
+        pipeline = _make_pipeline()
+
+        published_events: list[Event] = []
+        original_publish = pipeline.event_bus.publish
+
+        async def capture_publish(event, **kwargs):
+            if isinstance(event, Event):
+                published_events.append(event)
+            return await original_publish(event, **kwargs)
+
+        pipeline.event_bus.publish = capture_publish
+
+        asyncio.run(pipeline.run_evolution_cycle(iterations=1))
+
+        completed = [e for e in published_events if e.event_type == EventType.EVOLUTION_COMPLETED]
+        assert len(completed) == 1, f"Expected 1 EVOLUTION_COMPLETED, got {len(completed)}"
+        assert completed[0].source == "evolution_pipeline"
+        assert "iterations_completed" in completed[0].data
+        assert "successful_iterations" in completed[0].data
+
+
+class TestRunEvolutionCycleWithSafetyEvents:
+    """run_evolution_cycle_with_safety must not raise TypeError and must publish correct events."""
+
+    def test_completes_without_typeerror(self):
+        """A normal run must complete without TypeError."""
+        pipeline = _make_pipeline()
+        results = asyncio.run(pipeline.run_evolution_cycle_with_safety(iterations=1))
+        assert isinstance(results, list)
+
+    def test_publishes_evolution_completed(self):
+        """Must publish EVOLUTION_COMPLETED with correct data."""
+        import evoseal.core.evolution_pipeline as ep_mod
+
+        # Re-import to get the real module reference
+        _ensure_real_pipeline_module()
+        import importlib
+
+        ep_mod = importlib.import_module("evoseal.core.evolution_pipeline")
+
+        pipeline = _make_pipeline()
+
+        published_events: list[Event] = []
+        original_publish = ep_mod.event_bus.publish
+
+        async def capture_publish(event, **kwargs):
+            if isinstance(event, Event):
+                published_events.append(event)
+            return await original_publish(event, **kwargs)
+
+        ep_mod.event_bus.publish = capture_publish
+        try:
+            asyncio.run(pipeline.run_evolution_cycle_with_safety(iterations=1))
+        finally:
+            ep_mod.event_bus.publish = original_publish
+
+        completed = [e for e in published_events if e.event_type == EventType.EVOLUTION_COMPLETED]
+        assert len(completed) == 1, f"Expected 1 EVOLUTION_COMPLETED, got {len(completed)}"
+        assert completed[0].source == "evolution_pipeline"
+        assert "iterations_completed" in completed[0].data
+        assert "accepted_versions" in completed[0].data
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — resilience init must actually run
+# ---------------------------------------------------------------------------
+
+
+class TestResilienceInit:
+    """Resilience mechanisms must be registered after running a cycle."""
+
+    def test_resilience_not_initialized_before_cycle(self):
+        """Before any cycle, resilience should NOT be initialized (no sync init)."""
+        pipeline = _make_pipeline()
+        assert pipeline._resilience_initialized is False
+
+    def test_resilience_initialized_after_cycle(self):
+        """After run_evolution_cycle, resilience mechanisms must be registered."""
+        from evoseal.core.resilience import resilience_manager
+
+        pipeline = _make_pipeline()
+
+        # Clear any leftover state from previous tests
+        resilience_manager.circuit_breakers.clear()
+
+        asyncio.run(pipeline.run_evolution_cycle(iterations=1))
+
+        assert pipeline._resilience_initialized is True
+        assert "pipeline" in resilience_manager.circuit_breakers
+        assert "openevolve" in resilience_manager.circuit_breakers
+        assert "seal" in resilience_manager.circuit_breakers
+
+    def test_resilience_initialized_after_safety_cycle(self):
+        """After run_evolution_cycle_with_safety, resilience must be registered."""
+        from evoseal.core.resilience import resilience_manager
+
+        pipeline = _make_pipeline()
+
+        # Clear any leftover state from previous tests
+        resilience_manager.circuit_breakers.clear()
+
+        asyncio.run(pipeline.run_evolution_cycle_with_safety(iterations=1))
+
+        assert pipeline._resilience_initialized is True
+        assert "pipeline" in resilience_manager.circuit_breakers
+        assert "openevolve" in resilience_manager.circuit_breakers
+        assert "seal" in resilience_manager.circuit_breakers


### PR DESCRIPTION
## Bug 1 — unawaited async initialization (silent resilience bypass)

`EvolutionPipeline.__init__` called `self._init_resilience_mechanisms()` without `await`. Since `_init_resilience_mechanisms` is `async def`, this constructed and immediately discarded a coroutine object — Python emitted an unawaited-coroutine RuntimeWarning but no exception. **None of the resilience setup actually ran**: no monitoring, no circuit breakers for any component (pipeline/analyzer/generator/adapter/evaluator/validator/openevolve/seal), no recovery strategies, no degradation/fallback handlers, no escalation handler.

**Fix:** replaced the sync call with a lazy-init pattern. New `_ensure_resilience_initialized()` helper awaits `_init_resilience_mechanisms()` on first use, called at the start of both `run_evolution_cycle` and `run_evolution_cycle_with_safety`. A `_resilience_initialized` guard flag ensures setup runs exactly once. This matches the existing async-initialization pattern (the pipeline already has `initialize_components`/`start_components` as async entry points).

## Bug 2 — run_evolution_cycle always raises TypeError on success

`Event()` was constructed with 2 positional args (`EventType.EVOLUTION_COMPLETED`, dict) instead of the 3 required (`event_type`, `source`, `data`). The dict landed in the `source` field and `data` was left unfilled, raising `TypeError: Event.__init__() missing 1 required positional argument: 'data'`.

This crashed on **both** the success path and the error handler — the handler's TypeError masked the original error.

Additionally, the two `Event()` calls in `run_evolution_cycle` used `self.event_bus.publish()` **without await**, silently no-opping even if construction had succeeded.

**Same bug in `run_evolution_cycle_with_safety`** — 2 more malformed `Event()` calls (lines 676, 700). These had `await` but the Event constructor still raised TypeError.

**Fix:** all 4 malformed `Event()` calls now use keyword arguments (`event_type=`, `source=`, `data=`). The 2 missing `await` calls in `run_evolution_cycle` now have `await`.

## Tests

7 regression tests in `tests/unit/core/test_pipeline_init_and_events.py`:
- `test_completes_without_typeerror` — both cycle methods run without TypeError
- `test_publishes_evolution_completed` — correct event published with source/data
- `test_resilience_not_initialized_before_cycle` — no sync init (documents safe behavior)
- `test_resilience_initialized_after_cycle` — circuit breakers registered after use
- `test_resilience_initialized_after_safety_cycle` — same for safety variant

## Files changed

- `evoseal/core/evolution_pipeline.py` — Bug 1 + Bug 2 fixes
- `tests/unit/core/test_pipeline_init_and_events.py` — regression tests

## Verification

Full test suite: 505 passed, 2 skipped. Ruff check + format: clean.

Note: PR #76 (`fix/improvement-validation-stub`) also touches `evolution_pipeline.py` but in a different region (~line 919, `_validate_improvement`). These changes are non-overlapping.
