### PR TITLE
fix: training readiness check always rejects due to state set before check

### DIFF
--- a/evoseal/fine_tuning/training_manager.py
+++ b/evoseal/fine_tuning/training_manager.py
@@ -201,26 +201,27 @@ class TrainingManager:
         """
         try:
             cycle_start = datetime.now()
-            self.current_training = {
-                "start_time": cycle_start,
-                "status": "running",
-                "phase": "initialization",
-            }
 
             logger.info("Starting training cycle...")
 
-            # Phase 1: Check readiness
-            self.current_training["phase"] = "readiness_check"
+            # Phase 1: Check readiness BEFORE claiming training state.
+            # check_training_readiness() rejects if self.current_training is
+            # already set, so we must not set it until after the check passes.
             readiness = await self.check_training_readiness()
 
             if not readiness["ready"]:
-                self.current_training = None
                 return {
                     "success": False,
                     "phase": "readiness_check",
                     "error": readiness["reason"],
                     "details": readiness,
                 }
+
+            self.current_training = {
+                "start_time": cycle_start,
+                "status": "running",
+                "phase": "initialization",
+            }
 
             # Phase 2: Prepare training data
             self.current_training["phase"] = "data_preparation"

--- a/tests/unit/test_training_manager.py
+++ b/tests/unit/test_training_manager.py
@@ -1,0 +1,101 @@
+"""Regression tests for TrainingManager readiness-check ordering bug.
+
+Bug: run_training_cycle() set self.current_training BEFORE calling
+check_training_readiness(). Since the readiness check treats any non-None
+current_training as "already in progress", every call was rejected.
+
+Fix: check_training_readiness() is now called BEFORE setting
+self.current_training.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from evoseal.fine_tuning.training_manager import TrainingManager
+
+
+def _make_manager(min_samples: int = 10) -> TrainingManager:
+    """Build a TrainingManager with a mock data_collector that reports enough samples."""
+    collector = MagicMock()
+    collector.get_statistics.return_value = {"training_candidates": min_samples + 5}
+    return TrainingManager(data_collector=collector, min_training_samples=min_samples)
+
+
+@pytest.mark.asyncio
+async def test_run_training_cycle_passes_readiness_gate():
+    """run_training_cycle must get past the readiness check when no real
+    training is in progress and enough samples exist.
+
+    Before the fix this always failed with "Training already in progress"
+    because current_training was set before the check.
+    """
+    manager = _make_manager()
+
+    # Stub out the heavy phases so we only exercise the readiness gate.
+    # We let the method run until it hits prepare_training_data (Phase 2),
+    # then raise to stop early — the important assertion is that we got
+    # past the readiness check without being rejected.
+    async def _fake_prepare():
+        return {"success": False, "error": "stopped early for test"}
+
+    manager.prepare_training_data = _fake_prepare  # type: ignore[assignment]
+
+    result = await manager.run_training_cycle()
+
+    # We should NOT have been rejected at the readiness phase.
+    assert result.get("phase") != "readiness_check", (
+        f"Readiness check rejected: {result.get('error')}"
+    )
+    # We should have reached data_preparation (phase 2) and failed there
+    # because our stub returns success=False.
+    assert result.get("phase") == "data_preparation"
+
+
+@pytest.mark.asyncio
+async def test_readiness_rejects_genuinely_concurrent_training():
+    """If a training cycle is genuinely already in progress (current_training
+    set externally / by a prior incomplete run), the readiness check must
+    still reject a second call.
+    """
+    manager = _make_manager()
+
+    # Simulate a genuinely in-progress training by setting current_training
+    # BEFORE calling check_training_readiness (the normal guard path).
+    manager.current_training = {
+        "start_time": "2026-01-01T00:00:00",
+        "status": "running",
+        "phase": "fine_tuning",
+    }
+
+    readiness = await manager.check_training_readiness()
+    assert readiness["ready"] is False
+    assert "already in progress" in readiness["reason"]
+
+
+@pytest.mark.asyncio
+async def test_check_training_readiness_no_false_positive():
+    """check_training_readiness must not reject when current_training is None
+    and all other conditions are met.
+    """
+    manager = _make_manager()
+    assert manager.current_training is None
+
+    readiness = await manager.check_training_readiness()
+    assert readiness["ready"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_training_cycle_resets_state_on_readiness_failure():
+    """After a readiness failure, current_training must remain None (not leak)."""
+    manager = _make_manager()
+    # Override to report fewer candidates than required so readiness fails.
+    manager.data_collector.get_statistics.return_value = {"training_candidates": 0}
+
+    result = await manager.run_training_cycle()
+    assert result["success"] is False
+    assert result["phase"] == "readiness_check"
+    assert manager.current_training is None


### PR DESCRIPTION
## Bug

In `run_training_cycle()`, `self.current_training` was set at line 204 *before* `check_training_readiness()` was called at line 214. The readiness check (lines 105-108) treats any non-None `current_training` as "a training cycle is already in progress" and returns not-ready.

**Impact:** Since `current_training` is always set before the check, the readiness check always sees a training "in progress" (the one it just started) and always rejects. Every call to `run_training_cycle` fails at the readiness phase. The automated fine-tuning pipeline can never execute a training cycle.

This is the same bug class as the `deploy_version` supersede-before-confirm ordering bug fixed in `version_manager.py` (PR #72, commit dd8364fa).

## Fix

Reordered `run_training_cycle()` so `check_training_readiness()` is called **before** `self.current_training` is set. The readiness check does not need `current_training` to be set — it only reads it to detect concurrent training, which is exactly the guard that must run before state is claimed.

## Regression tests

4 tests in `tests/unit/test_training_manager.py`:

| Test | What it verifies |
|------|-----------------|
| `test_run_training_cycle_passes_readiness_gate` | A normal call gets past the readiness check (was always rejected before the fix) |
| `test_readiness_rejects_genuinely_concurrent_training` | The guard still works when a real training IS in progress |
| `test_check_training_readiness_no_false_positive` | No false rejection when `current_training` is None |
| `test_run_training_cycle_resets_state_on_readiness_failure` | No state leak after readiness failure |

## Verification

Full test suite: 502 passed, 23 deselected. Ruff format/check: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved training readiness handling so training is only marked as active after readiness checks succeed.
  - Prevented stale or incorrect training state when readiness checks fail.
  - Preserved detection of genuinely concurrent training runs.

- **Tests**
  - Added regression coverage for readiness checks, concurrent training detection, and state cleanup after failed readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->