### PR TITLE
fix: BaseEditStrategy.apply() corrupts content when original_text is empty

### DIFF
--- a/evoseal/integration/seal/self_editor/strategies/base_strategy.py
+++ b/evoseal/integration/seal/self_editor/strategies/base_strategy.py
@@ -50,6 +50,14 @@ class BaseEditStrategy(ABC):
             return content
 
         if hasattr(suggestion, "original_text") and hasattr(suggestion, "suggested_text"):
+            # Guard against empty original_text: "" in content is always True,
+            # and content.replace("", text) inserts text at every character
+            # boundary, corrupting the content.  For empty original_text,
+            # prepend suggested_text (matching SelfEditor.apply_edit ADD semantics).
+            if not suggestion.original_text:
+                if suggestion.suggested_text:
+                    return f"{suggestion.suggested_text}{content}"
+                return content
             if suggestion.original_text in content:
                 return content.replace(suggestion.original_text, suggestion.suggested_text)
         return content

--- a/tests/unit/seal/self_editor/strategies/test_base_strategy.py
+++ b/tests/unit/seal/self_editor/strategies/test_base_strategy.py
@@ -1,0 +1,120 @@
+"""Regression tests for BaseEditStrategy.apply() empty original_text bug.
+
+Bug: when original_text is "", `"" in content` is always True in Python, so
+apply() hit `content.replace("", suggested_text)` which inserts suggested_text
+at every character boundary, corrupting/bloating the content.
+
+Fix: apply() now checks for empty original_text and prepends suggested_text
+(matching SelfEditor.apply_edit ADD semantics) instead of calling replace.
+"""
+
+import pytest
+
+from evoseal.integration.seal.self_editor.models import EditCriteria, EditOperation, EditSuggestion
+from evoseal.integration.seal.self_editor.strategies.code_style_strategy import CodeStyleStrategy
+from evoseal.integration.seal.self_editor.strategies.documentation_strategy import (
+    DocumentationStrategy,
+)
+
+
+@pytest.fixture
+def strategy():
+    """Concrete strategy for testing apply() in isolation."""
+    return CodeStyleStrategy()
+
+
+class TestEmptyOriginalText:
+    """apply() must not corrupt content when original_text is empty."""
+
+    def test_empty_original_nonempty_suggested_prepends(self, strategy):
+        """Empty original_text + non-empty suggested_text => prepend."""
+        content = "hello world"
+        suggestion = EditSuggestion(
+            operation=EditOperation.ADD,
+            criteria=[EditCriteria.DOCUMENTATION],
+            original_text="",
+            suggested_text="prefix: ",
+        )
+        result = strategy.apply(content, suggestion)
+        assert result == "prefix: hello world"
+
+    def test_empty_original_empty_suggested_noop(self, strategy):
+        """Empty original_text + empty suggested_text => no change."""
+        content = "unchanged"
+        suggestion = EditSuggestion(
+            operation=EditOperation.ADD,
+            criteria=[EditCriteria.DOCUMENTATION],
+            original_text="",
+            suggested_text="",
+        )
+        result = strategy.apply(content, suggestion)
+        assert result == "unchanged"
+
+    def test_empty_original_does_not_bloat(self, strategy):
+        """Must not call content.replace('', text) which would insert at every char boundary."""
+        content = "abcd"
+        suggestion = EditSuggestion(
+            operation=EditOperation.ADD,
+            criteria=[EditCriteria.DOCUMENTATION],
+            original_text="",
+            suggested_text="X",
+        )
+        result = strategy.apply(content, suggestion)
+        # If the bug were present, result would be "XaXbXcXdX" (len 9).
+        # Correct behavior: prepend => "Xabcd" (len 5).
+        assert result == "Xabcd"
+        assert len(result) == len(content) + len("X")
+
+
+class TestDocumentationStrategyApplyIntegration:
+    """Verify DocumentationStrategy-generated ADD suggestions work via apply()."""
+
+    def test_missing_function_docstring_suggestion_via_apply(self):
+        """A DocumentationStrategy ADD suggestion with empty original_text
+        must produce a valid docstring insertion, not corrupted content."""
+        strategy = DocumentationStrategy()
+        content = "def foo():\n    pass\n"
+        suggestions = strategy.evaluate(content)
+
+        # Find the function docstring ADD suggestion
+        add_suggestions = [
+            s
+            for s in suggestions
+            if s.operation == EditOperation.ADD
+            and "Missing docstring for function 'foo'" in s.explanation
+        ]
+        assert len(add_suggestions) >= 1, "Expected a missing-function-docstring suggestion"
+
+        suggestion = add_suggestions[0]
+        assert suggestion.original_text == ""
+
+        result = strategy.apply(content, suggestion)
+
+        # The docstring text should appear in the result exactly once,
+        # prepended — not inserted before every character.
+        assert suggestion.suggested_text in result
+        assert result.count(suggestion.suggested_text) == 1
+        # Content should be longer than original by roughly the docstring size,
+        # not massively bloated.
+        assert len(result) < len(content) + len(suggestion.suggested_text) + 5
+
+    def test_missing_class_docstring_suggestion_via_apply(self):
+        """Same as above but for a class docstring ADD suggestion."""
+        strategy = DocumentationStrategy()
+        content = "class Bar:\n    pass\n"
+        suggestions = strategy.evaluate(content)
+
+        add_suggestions = [
+            s
+            for s in suggestions
+            if s.operation == EditOperation.ADD
+            and "Missing docstring for class 'Bar'" in s.explanation
+        ]
+        assert len(add_suggestions) >= 1
+
+        suggestion = add_suggestions[0]
+        assert suggestion.original_text == ""
+
+        result = strategy.apply(content, suggestion)
+        assert suggestion.suggested_text in result
+        assert result.count(suggestion.suggested_text) == 1


### PR DESCRIPTION
## Bug

`BaseEditStrategy.apply()` in `base_strategy.py` has a latent corruption bug. When `original_text` is `""` (empty string):

1. `"" in content` is always `True` in Python
2. `content.replace("", suggested_text)` inserts `suggested_text` at every character boundary (len+1 insertion points), massively bloating/corrupting the content

Example: `"abcd".replace("", "X")` produces `"XaXbXcXdX"`.

## Exploit scenario

`DocumentationStrategy` deliberately constructs `EditSuggestion(operation=ADD, original_text="", suggested_text=docstring_text)` at 4 call sites (function/class/module docstring + type hint generation). If any code path calls `strategy.apply()` directly on these suggestions (as documented in the README and used in tests), the file content gets corrupted.

The primary production runtime (`SelfEditor.apply_edit()`) already guards against this correctly — it prepends for ADD operations with empty `original_text`. But `BaseEditStrategy.apply()` is public API and was not protected.

## Fix

Added an explicit check for empty `original_text` in `apply()`:
- Empty `original_text` + non-empty `suggested_text` → prepend (matching `SelfEditor.apply_edit` ADD semantics)
- Empty `original_text` + empty `suggested_text` → return content unchanged (no-op)
- Non-empty `original_text` → existing replace logic (unchanged)

## Tests

5 regression tests in `tests/unit/seal/self_editor/strategies/test_base_strategy.py`:
- Empty original + non-empty suggested prepends correctly
- Empty original + empty suggested is a no-op
- Empty original does not bloat content (the corruption scenario)
- DocumentationStrategy-generated function docstring ADD suggestion works via `apply()`
- DocumentationStrategy-generated class docstring ADD suggestion works via `apply()`

## Verification

Full test suite: 503 passed, 23 deselected. Ruff format/check: clean.
