### PR TITLE
fix: split -u and sign_key into separate argv tokens in tag()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,10 @@ This project and everyone participating in it is governed by our [Code of Conduc
 - Use the `SystemConfig` model (`evoseal.models.system_config.SystemConfig`) to load and validate configuration in new code:
   ```python
   from evoseal.models.system_config import SystemConfig
-  config = SystemConfig.from_yaml('configs/evoseal.yaml')
+
+  config = SystemConfig.from_yaml("configs/evoseal.yaml")
   config.validate()
-  value = config.get('dgm.max_iterations')
+  value = config.get("dgm.max_iterations")
   ```
 - Ensure any new configuration keys are documented and, if required, validated in your code.
 

--- a/TODO.md
+++ b/TODO.md
@@ -252,7 +252,7 @@
 
 ### Low-Priority / Hygiene Issues Found in Whole-Repo Code Review (2026-07-22)
 
-- [ ] **`cmd_git.py:977` `tag()` builds a malformed argv token** — `cmd.append("-s" if not sign_key else f"-u {sign_key}")` appends `"-u <key>"` as one argv element instead of `["-u", sign_key]`; since commands run via `subprocess.run(list, shell=False)`, git receives one malformed token and signed-tag-with-explicit-key fails
+- [x] **`cmd_git.py:977` `tag()` builds a malformed argv token** — `cmd.append("-s" if not sign_key else f"-u {sign_key}")` appends `"-u <key>"` as one argv element instead of `["-u", sign_key]`; since commands run via `subprocess.run(list, shell=False)`, git receives one malformed token and signed-tag-with-explicit-key fails
 - [ ] **`git_interface.py` credential-helper config is broken** — sets `credential.helper` to the literal string `'cache --timeout=300'` including the quotes (no shell involved, so they're taken literally), via two non-`--add` `--local` sets where the second silently overwrites the first with a bogus value — HTTPS credential caching silently doesn't work
 - [ ] **Stray `evoseal/utils/validator.py.bak`** — a 1132-line backup committed to the repo tree (not gitignored), diverged from `validator.py`; risk of editing the wrong file
 - [ ] **`evoseal/utils/testing/environment.py:180`** — `suffix: str = None` type-annotation mismatch (should be `Optional[str]`)
@@ -304,8 +304,8 @@
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 11   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
 | 🟡 P2    | 29    | 6    | Co-evolution loop gaps (7 items, 6 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
-| 🟢 P3    | 24    | 6    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
-| **Total** | **88** | **34** | |
+| 🟢 P3    | 24    | 7    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
+| **Total** | **88** | **35** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -372,15 +372,17 @@ ws.onclose = function() {
 import aiohttp
 import asyncio
 
+
 async def get_metrics():
     async with aiohttp.ClientSession() as session:
-        async with session.get('http://localhost:9613/api/metrics') as response:
+        async with session.get("http://localhost:9613/api/metrics") as response:
             if response.status == 200:
                 metrics = await response.json()
                 return metrics
             else:
                 print(f"Error: {response.status}")
                 return None
+
 
 # Usage
 metrics = asyncio.run(get_metrics())
@@ -393,6 +395,7 @@ import asyncio
 import websockets
 import json
 
+
 async def websocket_client():
     uri = "ws://localhost:9613/ws"
 
@@ -401,9 +404,10 @@ async def websocket_client():
             data = json.loads(message)
             print(f"Received {data['type']}: {data['timestamp']}")
 
-            if data['type'] == 'metrics_update':
+            if data["type"] == "metrics_update":
                 # Process metrics update
-                process_metrics(data['data'])
+                process_metrics(data["data"])
+
 
 # Usage
 asyncio.run(websocket_client())

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,10 +10,12 @@ The main class for interacting with the EVOSEAL system.
 
 ```python
 class EVOSEAL:
-    def __init__(self,
-                 model: Optional[BaseModel] = None,
-                 fitness_function: Optional[Callable] = None,
-                 config: Optional[Dict] = None):
+    def __init__(
+        self,
+        model: Optional[BaseModel] = None,
+        fitness_function: Optional[Callable] = None,
+        config: Optional[Dict] = None,
+    ):
         """
         Initialize the EVOSEAL system.
 
@@ -23,11 +25,9 @@ class EVOSEAL:
             config: Configuration dictionary
         """
 
-    def evolve(self,
-               task: str,
-               max_iterations: int = 100,
-               population_size: int = 20,
-               **kwargs) -> EvolutionResult:
+    def evolve(
+        self, task: str, max_iterations: int = 100, population_size: int = 20, **kwargs
+    ) -> EvolutionResult:
         """
         Run the evolutionary algorithm.
 
@@ -45,7 +45,7 @@ class EVOSEAL:
         """Save the current state to a checkpoint file."""
 
     @classmethod
-    def load_checkpoint(cls, filepath: str) -> 'EVOSEAL':
+    def load_checkpoint(cls, filepath: str) -> "EVOSEAL":
         """Load a previously saved checkpoint."""
 ```
 
@@ -136,6 +136,7 @@ def default_fitness(solution: str, **kwargs) -> float:
 def save_checkpoint(evoseal: EVOSEAL, filepath: str) -> None:
     """Save EVOSEAL instance to a file."""
 
+
 def load_checkpoint(filepath: str) -> EVOSEAL:
     """Load EVOSEAL instance from a file."""
 ```
@@ -154,7 +155,7 @@ evoseal = EVOSEAL()
 result = evoseal.evolve(
     task="Create a Python function that implements binary search",
     max_iterations=30,
-    population_size=15
+    population_size=15,
 )
 
 # Access results
@@ -167,14 +168,13 @@ print(f"Fitness: {result.fitness}")
 ```python
 from evoseal import EVOSEAL, OpenAIModel
 
+
 def custom_fitness(solution, **kwargs):
     # Your custom fitness logic here
     return score
 
+
 # Initialize with custom model and fitness
 model = OpenAIModel(model="gpt-4")
-evoseal = EVOSEAL(
-    model=model,
-    fitness_function=custom_fitness
-)
+evoseal = EVOSEAL(model=model, fitness_function=custom_fitness)
 ```

--- a/docs/architecture/bidirectional_evolution.md
+++ b/docs/architecture/bidirectional_evolution.md
@@ -188,9 +188,9 @@ improvement.
 ```python
 # Examples from regression_detector.py (inside metric_thresholds dict)
 metric_thresholds = {
-    "pass_rate":    {"regression": -0.05, "critical": -0.1},   # 5% / 10% drop
-    "duration_sec": {"regression":  0.10, "critical":  0.25},  # 10% / 25% slower
-    "correctness":  {"regression": -0.01, "critical": -0.05},  # 1% / 5% drop
+    "pass_rate": {"regression": -0.05, "critical": -0.1},  # 5% / 10% drop
+    "duration_sec": {"regression": 0.10, "critical": 0.25},  # 10% / 25% slower
+    "correctness": {"regression": -0.01, "critical": -0.05},  # 1% / 5% drop
 }
 ```
 

--- a/docs/architecture/core/agentic_system.md
+++ b/docs/architecture/core/agentic_system.md
@@ -37,6 +37,7 @@ system.broadcast_message("teamA", "Start round!")
 ## Async Support
 ```python
 import asyncio
+
 asyncio.run(system.assign_task_async("wf1", step))
 ```
 
@@ -45,10 +46,13 @@ asyncio.run(system.assign_task_async("wf1", step))
 class MyAgent:
     def act(self, observation):
         return f"Processed {observation}"
+
     def receive(self, message):
         print(f"Got message: {message}")
+
     def get_status(self):
         return {"status": "ok"}
+
 
 system.create_agent("a1", MyAgent())
 ```

--- a/docs/architecture/core/error_handling.md
+++ b/docs/architecture/core/error_handling.md
@@ -231,21 +231,9 @@ def get_user(user_id: str) -> dict:
 ### Example 2: Using error_handler
 
 ```python
-@error_handler(
-    ValidationError,
-    status_code=400,
-    logger=logger
-)
-@error_handler(
-    DatabaseError,
-    status_code=503,
-    logger=logger
-)
-@error_handler(
-    Exception,
-    status_code=500,
-    logger=logger
-)
+@error_handler(ValidationError, status_code=400, logger=logger)
+@error_handler(DatabaseError, status_code=503, logger=logger)
+@error_handler(Exception, status_code=500, logger=logger)
 def get_user_handler(user_id: str) -> tuple[dict, int]:
     user = get_user(user_id)
     return {"user": user}, 200

--- a/docs/architecture/core/error_handling_resilience.md
+++ b/docs/architecture/core/error_handling_resilience.md
@@ -43,12 +43,8 @@ error = BaseError(
     "Database connection failed",
     code="DB_CONNECTION_ERROR",
     category=ErrorCategory.INTEGRATION,
-    severity=ErrorSeverity.ERROR
-).with_context(
-    component="database",
-    operation="connect",
-    retry_count=3
-)
+    severity=ErrorSeverity.ERROR,
+).with_context(component="database", operation="connect", retry_count=3)
 ```
 
 ### 2. Resilience Manager (`evoseal.core.resilience`)
@@ -61,11 +57,7 @@ from evoseal.core.resilience import resilience_manager, CircuitBreakerConfig
 # Register circuit breaker
 resilience_manager.register_circuit_breaker(
     "api_service",
-    CircuitBreakerConfig(
-        failure_threshold=5,
-        recovery_timeout=60,
-        success_threshold=3
-    )
+    CircuitBreakerConfig(failure_threshold=5, recovery_timeout=60, success_threshold=3),
 )
 
 # Execute with resilience
@@ -81,17 +73,19 @@ Provides intelligent error recovery with multiple strategies:
 ```python
 from evoseal.core.error_recovery import with_error_recovery, RecoveryStrategy
 
+
 @with_error_recovery("component", "operation")
 async def risky_operation():
     # Your code here
     pass
+
 
 # Custom recovery strategy
 strategy = RecoveryStrategy(
     max_retries=5,
     retry_delay=2.0,
     backoff_multiplier=1.5,
-    recovery_actions=[RecoveryAction.RETRY, RecoveryAction.FALLBACK]
+    recovery_actions=[RecoveryAction.RETRY, RecoveryAction.FALLBACK],
 )
 ```
 
@@ -110,7 +104,7 @@ logger.log_component_operation(
     operation="fetch_data",
     status="success",
     duration=1.5,
-    records_processed=100
+    records_processed=100,
 )
 
 # Error logging with context
@@ -119,7 +113,7 @@ logger.log_error_with_context(
     component="api_client",
     operation="fetch_data",
     request_id="req_123",
-    user_id="user_456"
+    user_id="user_456",
 )
 ```
 
@@ -170,7 +164,7 @@ error = BaseError("Operation failed").with_context(
     operation="transform_data",
     input_size=1000,
     memory_usage="512MB",
-    execution_time=30.5
+    execution_time=30.5,
 )
 ```
 
@@ -181,11 +175,13 @@ Use decorators for automatic error handling:
 ```python
 from evoseal.core.errors import handle_errors, retry_on_error, error_boundary
 
+
 @handle_errors(reraise=True, log_level=logging.ERROR)
 @retry_on_error(max_retries=3, delay=1.0)
 async def network_operation():
     # Network call that may fail
     pass
+
 
 @error_boundary(default="fallback_value")
 def safe_operation():
@@ -202,10 +198,10 @@ Circuit breakers prevent cascade failures by isolating failing components:
 ```python
 # Configure circuit breaker
 config = CircuitBreakerConfig(
-    failure_threshold=5,      # Open after 5 failures
-    recovery_timeout=60,      # Wait 60s before testing
-    success_threshold=3,      # Close after 3 successes
-    timeout=30.0             # Operation timeout
+    failure_threshold=5,  # Open after 5 failures
+    recovery_timeout=60,  # Wait 60s before testing
+    success_threshold=3,  # Close after 3 successes
+    timeout=30.0,  # Operation timeout
 )
 
 resilience_manager.register_circuit_breaker("service_name", config)
@@ -270,11 +266,7 @@ strategy = RecoveryStrategy(
     backoff_multiplier=2.0,
     max_delay=60.0,
     timeout=30.0,
-    recovery_actions=[
-        RecoveryAction.RETRY,
-        RecoveryAction.FALLBACK,
-        RecoveryAction.ESCALATE
-    ]
+    recovery_actions=[RecoveryAction.RETRY, RecoveryAction.FALLBACK, RecoveryAction.ESCALATE],
 )
 ```
 
@@ -287,9 +279,8 @@ async def api_fallback(*args, context=None, **kwargs):
     # Return cached data or default response
     return {"status": "fallback", "data": cached_data}
 
-error_recovery_manager.fallback_manager.register_fallback(
-    "api_service", "fetch_data", api_fallback
-)
+
+error_recovery_manager.fallback_manager.register_fallback("api_service", "fetch_data", api_fallback)
 ```
 
 ### Custom Recovery Actions
@@ -302,6 +293,7 @@ async def custom_recovery(component: str, operation: str, error: Exception):
     logger.info(f"Executing custom recovery for {component}")
     await restart_component(component)
     await clear_cache(component)
+
 
 error_recovery_manager.register_recovery_strategy("component", custom_recovery)
 ```
@@ -316,12 +308,7 @@ All logging uses structured format with rich context:
 logger = get_logger("component_name")
 
 # Pipeline stage logging
-logger.log_pipeline_stage(
-    stage="data_processing",
-    status="started",
-    iteration=5,
-    input_size=1000
-)
+logger.log_pipeline_stage(stage="data_processing", status="started", iteration=5, input_size=1000)
 
 # Component operation logging
 logger.log_component_operation(
@@ -330,15 +317,12 @@ logger.log_component_operation(
     status="success",
     duration=2.5,
     records_processed=1000,
-    memory_used="256MB"
+    memory_used="256MB",
 )
 
 # Performance metric logging
 logger.log_performance_metric(
-    metric_name="throughput",
-    value=500,
-    unit="records/sec",
-    component="processor"
+    metric_name="throughput", value=500, unit="records/sec", component="processor"
 )
 ```
 
@@ -354,11 +338,7 @@ print(f"Error rate: {metrics.error_rate:.2%}")
 print(f"Logs per minute: {metrics.avg_logs_per_minute}")
 
 # Recent logs with filtering
-recent_errors = logger.get_recent_logs(
-    count=50,
-    level=LogLevel.ERROR,
-    component="api_client"
-)
+recent_errors = logger.get_recent_logs(count=50, level=LogLevel.ERROR, component="api_client")
 ```
 
 ### Log Aggregation
@@ -402,6 +382,7 @@ For custom components, integrate resilience manually:
 from evoseal.core.resilience import resilience_manager
 from evoseal.core.error_recovery import with_error_recovery
 
+
 class MyComponent:
     @with_error_recovery("my_component", "process_data")
     async def process_data(self, data):
@@ -421,12 +402,14 @@ Resilience events are published to the event system:
 ```python
 from evoseal.core.events import event_bus
 
+
 # Subscribe to resilience events
 async def handle_resilience_event(event):
     if event.event_type == "ERROR_RECOVERY_SUCCESS":
         print(f"Recovery successful: {event.data}")
     elif event.event_type == "CIRCUIT_BREAKER_OPEN":
         print(f"Circuit breaker opened: {event.data}")
+
 
 event_bus.subscribe("ERROR_RECOVERY_SUCCESS", handle_resilience_event)
 event_bus.subscribe("CIRCUIT_BREAKER_OPEN", handle_resilience_event)
@@ -510,7 +493,7 @@ Automatic health monitoring with configurable intervals:
 health_status = await resilience_orchestrator._perform_health_checks()
 
 print(f"Overall health: {health_status['overall_health']}")
-for component, status in health_status['components'].items():
+for component, status in health_status["components"].items():
     print(f"{component}: {status['status']} ({status['success_rate']:.2%})")
 ```
 
@@ -520,12 +503,13 @@ Custom alert handlers for different scenarios:
 
 ```python
 async def custom_alert_handler(alert):
-    if alert['type'] == 'high_error_rate':
+    if alert["type"] == "high_error_rate":
         # Send notification
         await send_notification(f"High error rate: {alert['error_rate']:.2%}")
-    elif alert['type'] == 'component_unhealthy':
+    elif alert["type"] == "component_unhealthy":
         # Restart component
-        await restart_component(alert['component'])
+        await restart_component(alert["component"])
+
 
 resilience_orchestrator.alert_handlers.append(custom_alert_handler)
 ```
@@ -656,6 +640,7 @@ status = await resilience_orchestrator.get_comprehensive_status()
 
 # Pretty print status
 import json
+
 print(json.dumps(status, indent=2, default=str))
 ```
 
@@ -665,6 +650,7 @@ print(json.dumps(status, indent=2, default=str))
 # Subscribe to all resilience events
 async def debug_event_handler(event):
     print(f"Event: {event.event_type} - {event.data}")
+
 
 event_bus.subscribe("ERROR_RECOVERY_SUCCESS", debug_event_handler)
 event_bus.subscribe("CIRCUIT_BREAKER_OPEN", debug_event_handler)
@@ -725,13 +711,23 @@ def with_error_recovery(component: str, operation: str, recovery_strategy: Recov
 
 #### `@handle_errors`
 ```python
-def handle_errors(error_types: Tuple[Type[Exception], ...] = None, reraise: bool = True, log_level: int = logging.ERROR, default_message: str = "An error occurred"):
+def handle_errors(
+    error_types: Tuple[Type[Exception], ...] = None,
+    reraise: bool = True,
+    log_level: int = logging.ERROR,
+    default_message: str = "An error occurred",
+):
     """Decorator for comprehensive error handling."""
 ```
 
 #### `@retry_on_error`
 ```python
-def retry_on_error(max_retries: int = 3, delay: float = 1.0, backoff: float = 2.0, exceptions: Tuple[Type[Exception], ...] = (Exception,)):
+def retry_on_error(
+    max_retries: int = 3,
+    delay: float = 1.0,
+    backoff: float = 2.0,
+    exceptions: Tuple[Type[Exception], ...] = (Exception,),
+):
     """Decorator to retry functions on error."""
 ```
 

--- a/docs/architecture/core/event_system.md
+++ b/docs/architecture/core/event_system.md
@@ -54,14 +54,17 @@ Events are represented by the `Event` class, which contains:
 ```python
 engine = WorkflowEngine()
 
+
 # Using decorator syntax
 @engine.register_event_handler(EventType.WORKFLOW_STARTED)
 def on_workflow_start(event):
     print(f"Workflow started: {event.data['workflow']}")
 
+
 # Using method call
 def on_step_complete(event):
     print(f"Step completed: {event.data['step']}")
+
 
 engine.register_event_handler(EventType.STEP_COMPLETED, on_step_complete)
 ```
@@ -71,8 +74,10 @@ engine.register_event_handler(EventType.STEP_COMPLETED, on_step_complete)
 ```python
 from evoseal.core.events import event_bus
 
+
 def custom_handler(event):
     print(f"Custom event: {event.data}")
+
 
 event_bus.subscribe("custom_event", custom_handler)
 ```
@@ -122,7 +127,8 @@ Filter which events are handled:
 
 ```python
 def only_important(event):
-    return event.data.get('priority', 0) > 5
+    return event.data.get("priority", 0) > 5
+
 
 @engine.register_event_handler("data_ready", filter_fn=only_important)
 def handle_important_data(event):
@@ -138,6 +144,7 @@ Control the order of handler execution:
 def high_priority_handler(event):
     print("This runs first")
 
+
 @engine.register_event_handler("process_data", priority=1)
 def low_priority_handler(event):
     print("This runs later")
@@ -152,9 +159,10 @@ Emit and handle custom events:
 event = Event(
     event_type="data_processed",
     source="data_processor",
-    data={"result": "success", "items_processed": 42}
+    data={"result": "success", "items_processed": 42},
 )
 await event_bus.publish(event)
+
 
 # Subscribe to custom events
 @event_bus.subscribe("data_processed")
@@ -177,29 +185,24 @@ def on_data_processed(event):
 class WorkflowMonitor:
     def __init__(self, engine):
         self.engine = engine
-        self.stats = {
-            'started': 0,
-            'completed': 0,
-            'failed': 0,
-            'steps': {}
-        }
+        self.stats = {"started": 0, "completed": 0, "failed": 0, "steps": {}}
         self._register_handlers()
 
     def _register_handlers(self):
         @self.engine.register_event_handler(EventType.WORKFLOW_STARTED)
         def on_start(event):
-            self.stats['started'] += 1
+            self.stats["started"] += 1
             print(f"Workflow started: {event.data['workflow']}")
 
         @self.engine.register_event_handler(EventType.WORKFLOW_COMPLETED)
         def on_complete(event):
-            self.stats['completed'] += 1
+            self.stats["completed"] += 1
             print(f"Workflow completed: {event.data['workflow']}")
 
         @self.engine.register_event_handler(EventType.STEP_COMPLETED)
         def on_step_complete(event):
-            step_name = event.data['step']
-            self.stats['steps'][step_name] = self.stats['steps'].get(step_name, 0) + 1
+            step_name = event.data["step"]
+            self.stats["steps"][step_name] = self.stats["steps"].get(step_name, 0) + 1
 ```
 
 This documentation provides a comprehensive guide to using the event system in the EVOSEAL workflow engine.

--- a/docs/architecture/core/index.md
+++ b/docs/architecture/core/index.md
@@ -94,16 +94,11 @@ from evoseal.core.orchestration import WorkflowOrchestrator
 # Initialize core systems
 event_bus = EventBus()
 resilience = ResilienceManager(event_bus=event_bus)
-orchestrator = WorkflowOrchestrator(
-    event_bus=event_bus,
-    resilience_manager=resilience
-)
+orchestrator = WorkflowOrchestrator(event_bus=event_bus, resilience_manager=resilience)
 
 # Publish events
 event = create_component_event(
-    component_type="evolution_pipeline",
-    component_id="main",
-    operation="started"
+    component_type="evolution_pipeline", component_id="main", operation="started"
 )
 event_bus.publish(event)
 ```

--- a/docs/architecture/core/knowledge_base.md
+++ b/docs/architecture/core/knowledge_base.md
@@ -22,8 +22,7 @@ kb = KnowledgeBase("knowledge_base.json")
 
 # Add an entry
 entry_id = kb.add_entry(
-    "Python is a high-level programming language.",
-    tags=["programming", "python"]
+    "Python is a high-level programming language.", tags=["programming", "python"]
 )
 
 # Retrieve an entry
@@ -50,13 +49,11 @@ seal_kb = SEALKnowledge(KnowledgeBase("seal_knowledge.json"))
 seal_kb.learn_from_interaction(
     prompt="How to implement quicksort in Python?",
     response="Here's a Python implementation of quicksort...",
-    tags=["algorithm", "python", "sorting"]
+    tags=["algorithm", "python", "sorting"],
 )
 
 # Enhance a prompt with relevant knowledge
-enhanced_prompt = seal_kb.enhance_prompt(
-    "I need to implement a sorting algorithm in Python"
-)
+enhanced_prompt = seal_kb.enhance_prompt("I need to implement a sorting algorithm in Python")
 print(enhanced_prompt)
 ```
 

--- a/docs/architecture/core/prompt_template_system.md
+++ b/docs/architecture/core/prompt_template_system.md
@@ -50,12 +50,13 @@ The `TemplateManager` class (see `openevolve/openevolve/prompt/templates.py`) pr
 ```python
 from openevolve.prompt.templates import TemplateManager
 import os
-TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), '../evoseal/prompt_templates/dgm')
+
+TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "../evoseal/prompt_templates/dgm")
 template_manager = TemplateManager(TEMPLATE_DIR)
 
-prompt = template_manager.get_template('diagnose_improvement_prompt')
-meta = template_manager.get_metadata('diagnose_improvement_prompt')
-print(meta['category'], meta['description'])
+prompt = template_manager.get_template("diagnose_improvement_prompt")
+meta = template_manager.get_metadata("diagnose_improvement_prompt")
+print(meta["category"], meta["description"])
 ```
 
 ## Best Practices

--- a/docs/architecture/core/version_control_experiment_tracking.md
+++ b/docs/architecture/core/version_control_experiment_tracking.md
@@ -42,9 +42,7 @@ db.save_experiment(experiment)
 
 # Query experiments
 experiments = db.list_experiments(
-    status=ExperimentStatus.COMPLETED,
-    experiment_type=ExperimentType.EVOLUTION,
-    limit=10
+    status=ExperimentStatus.COMPLETED, experiment_type=ExperimentType.EVOLUTION, limit=10
 )
 ```
 
@@ -64,14 +62,11 @@ version_db.add_variant(
     source="def solution(): return 42",
     test_results={"passed": True},
     eval_score=0.95,
-    experiment_id="exp_123"
+    experiment_id="exp_123",
 )
 
 # Get best variants
-best_variants = version_db.get_best_variants(
-    experiment_id="exp_123",
-    limit=5
-)
+best_variants = version_db.get_best_variants(experiment_id="exp_123", limit=5)
 ```
 
 ### 3. VersionTracker
@@ -86,20 +81,14 @@ tracker = VersionTracker(work_dir="./evoseal_workspace")
 
 # Create experiment with version info
 experiment = tracker.create_experiment_with_version(
-    name="Evolution Run 1",
-    config=experiment_config,
-    repository_name="my_repo",
-    branch="main"
+    name="Evolution Run 1", config=experiment_config, repository_name="my_repo", branch="main"
 )
 
 # Start experiment
 tracker.start_experiment(experiment.id)
 
 # Create checkpoint
-checkpoint_id = tracker.create_checkpoint(
-    experiment.id,
-    checkpoint_name="mid_evolution"
-)
+checkpoint_id = tracker.create_checkpoint(experiment.id, checkpoint_name="mid_evolution")
 ```
 
 ### 4. ExperimentIntegration
@@ -114,18 +103,14 @@ integration = ExperimentIntegration(version_tracker)
 
 # Create and start experiment
 experiment = integration.create_evolution_experiment(
-    name="My Evolution Run",
-    config=config_dict,
-    repository_name="my_repo"
+    name="My Evolution Run", config=config_dict, repository_name="my_repo"
 )
 
 integration.start_evolution_experiment()
 
 # Track iteration
 integration.track_iteration_complete(
-    iteration=5,
-    fitness_scores=[0.1, 0.3, 0.8, 0.6],
-    best_fitness=0.8
+    iteration=5, fitness_scores=[0.1, 0.3, 0.8, 0.6], best_fitness=0.8
 )
 
 # Complete experiment
@@ -151,7 +136,7 @@ config = ExperimentConfig(
     selection_pressure=2.0,
     dgm_config={"param1": "value1"},
     openevolve_config={"param2": "value2"},
-    seal_config={"param3": "value3"}
+    seal_config={"param3": "value3"},
 )
 ```
 
@@ -167,7 +152,7 @@ experiment = Experiment(
     description="Testing evolution parameters",
     config=config,
     tags=["evolution", "test"],
-    created_by="researcher"
+    created_by="researcher",
 )
 
 # Add metrics
@@ -176,9 +161,7 @@ experiment.add_metric("execution_time", 120.5, MetricType.EXECUTION_TIME)
 
 # Add artifacts
 artifact = experiment.add_artifact(
-    name="final_model",
-    artifact_type="model",
-    file_path="/path/to/model.pkl"
+    name="final_model", artifact_type="model", file_path="/path/to/model.pkl"
 )
 
 # Control experiment lifecycle
@@ -194,11 +177,7 @@ Track metrics during experiments:
 from evoseal.models.experiment import ExperimentMetric, MetricType
 
 metric = ExperimentMetric(
-    name="best_fitness",
-    value=0.92,
-    metric_type=MetricType.ACCURACY,
-    iteration=10,
-    step=500
+    name="best_fitness", value=0.92, metric_type=MetricType.ACCURACY, iteration=10, step=500
 )
 ```
 
@@ -213,31 +192,23 @@ Automatic git integration tracks code changes:
 repo_manager = RepositoryManager(work_dir)
 
 # Clone repository
-repo_path = repo_manager.clone_repository(
-    "https://github.com/user/repo.git",
-    "my_repo"
-)
+repo_path = repo_manager.clone_repository("https://github.com/user/repo.git", "my_repo")
 
 # Create experiment with git info
 experiment = version_tracker.create_experiment_with_version(
     name="Experiment with Git",
     config=config,
     repository_name="my_repo",
-    branch="feature/new-algorithm"
+    branch="feature/new-algorithm",
 )
 
 # Automatic commit before starting
 version_tracker.start_experiment(
-    experiment.id,
-    auto_commit=True,
-    commit_message="Starting experiment"
+    experiment.id, auto_commit=True, commit_message="Starting experiment"
 )
 
 # Automatic tagging on completion
-version_tracker.complete_experiment(
-    experiment.id,
-    create_tag=True
-)
+version_tracker.complete_experiment(experiment.id, create_tag=True)
 ```
 
 ### Code Versioning
@@ -253,7 +224,7 @@ integration.track_variant_creation(
     eval_score=fitness_score,
     parent_ids=["variant_gen4_ind1", "variant_gen4_ind7"],
     generation=5,
-    mutation_type="crossover"
+    mutation_type="crossover",
 )
 
 # Get variant lineage
@@ -272,6 +243,7 @@ history = version_db.get_evolution_history()
 import asyncio
 from evoseal.core.experiment_integration import create_experiment_integration
 
+
 async def run_tracked_evolution():
     # Create integration
     integration = create_experiment_integration("./workspace")
@@ -281,13 +253,11 @@ async def run_tracked_evolution():
         "experiment_type": "evolution",
         "population_size": 30,
         "max_iterations": 50,
-        "mutation_rate": 0.1
+        "mutation_rate": 0.1,
     }
 
     experiment = integration.create_evolution_experiment(
-        name="Tracked Evolution Run",
-        config=config,
-        description="Evolution with full tracking"
+        name="Tracked Evolution Run", config=config, description="Evolution with full tracking"
     )
 
     # Start experiment
@@ -302,19 +272,17 @@ async def run_tracked_evolution():
         best_fitness = max(fitness_scores)
 
         integration.track_iteration_complete(
-            iteration=iteration,
-            fitness_scores=fitness_scores,
-            best_fitness=best_fitness
+            iteration=iteration, fitness_scores=fitness_scores, best_fitness=best_fitness
         )
 
         # Track performance
         integration.track_performance_metrics(
-            execution_time=measure_time(),
-            memory_usage=measure_memory()
+            execution_time=measure_time(), memory_usage=measure_memory()
         )
 
     # Complete experiment
     integration.complete_evolution_experiment()
+
 
 # Run the experiment
 asyncio.run(run_tracked_evolution())
@@ -328,11 +296,11 @@ experiment_ids = ["exp1", "exp2", "exp3"]
 comparison = version_tracker.compare_experiments(experiment_ids)
 
 print("Configuration differences:")
-for param, values in comparison['configurations']['different_parameters'].items():
+for param, values in comparison["configurations"]["different_parameters"].items():
     print(f"  {param}: {values}")
 
 print("Metric comparison:")
-for metric, values in comparison['metrics'].items():
+for metric, values in comparison["metrics"].items():
     print(f"  {metric}: {values}")
 ```
 
@@ -350,10 +318,7 @@ restored_experiment = version_tracker.restore_checkpoint(checkpoint_id)
 
 ```python
 # Export variants
-version_db.export_variants(
-    experiment_id="exp_123",
-    file_path="variants_backup.json"
-)
+version_db.export_variants(experiment_id="exp_123", file_path="variants_backup.json")
 
 # Import variants
 new_db = VersionDatabase()
@@ -416,7 +381,7 @@ experiment = integration.create_evolution_experiment(
     name="DGM_Optimization_v2.1_20240101",
     description="Testing new mutation operators with DGM",
     tags=["dgm", "mutation", "optimization", "v2.1"],
-    created_by="researcher_id"
+    created_by="researcher_id",
 )
 ```
 
@@ -428,9 +393,9 @@ integration.track_iteration_complete(
     iteration=i,
     fitness_scores=scores,
     best_fitness=max(scores),
-    avg_fitness=sum(scores)/len(scores),
+    avg_fitness=sum(scores) / len(scores),
     diversity_score=calculate_diversity(population),
-    convergence_rate=calculate_convergence(scores)
+    convergence_rate=calculate_convergence(scores),
 )
 ```
 
@@ -448,16 +413,11 @@ if iteration % 10 == 0:
 ```python
 # Store important artifacts
 integration.add_artifact(
-    name="best_individual",
-    artifact_type="code",
-    content=best_code,
-    fitness_score=best_fitness
+    name="best_individual", artifact_type="code", content=best_code, fitness_score=best_fitness
 )
 
 integration.add_artifact(
-    name="evolution_plot",
-    artifact_type="visualization",
-    file_path="fitness_evolution.png"
+    name="evolution_plot", artifact_type="visualization", file_path="fitness_evolution.png"
 )
 ```
 
@@ -485,18 +445,9 @@ config = ExperimentConfig(
     max_iterations=100,
     population_size=50,
     # Component-specific configs
-    dgm_config={
-        "output_dir": "./dgm_output",
-        "prevrun_dir": "./dgm_previous"
-    },
-    openevolve_config={
-        "timeout": 300,
-        "parallel_jobs": 4
-    },
-    seal_config={
-        "provider": "openai",
-        "model": "gpt-4"
-    }
+    dgm_config={"output_dir": "./dgm_output", "prevrun_dir": "./dgm_previous"},
+    openevolve_config={"timeout": 300, "parallel_jobs": 4},
+    seal_config={"provider": "openai", "model": "gpt-4"},
 )
 ```
 
@@ -505,10 +456,7 @@ config = ExperimentConfig(
 ```python
 # Regular cleanup of old experiments
 old_experiments = db.list_experiments(
-    status=ExperimentStatus.FAILED,
-    limit=100,
-    order_by="created_at",
-    order_desc=False
+    status=ExperimentStatus.FAILED, limit=100, order_by="created_at", order_desc=False
 )
 
 for exp in old_experiments[:50]:  # Keep only recent 50 failed

--- a/docs/architecture/core/workflow_orchestration.md
+++ b/docs/architecture/core/workflow_orchestration.md
@@ -136,7 +136,9 @@ if success:
     # Execute workflow
     result = await orchestrator.execute_workflow(pipeline_instance)
 
-    print(f"Workflow completed: {result.success_count}/{len(result.iterations)} iterations successful")
+    print(
+        f"Workflow completed: {result.success_count}/{len(result.iterations)} iterations successful"
+    )
     print(f"Total execution time: {result.total_execution_time:.2f}s")
     print(f"Checkpoints created: {result.checkpoints_created}")
 ```
@@ -168,12 +170,12 @@ orchestrator = WorkflowOrchestrator(
 
 ```python
 resource_thresholds = ResourceThresholds(
-    memory_warning=0.7,      # 70% memory usage warning
-    memory_critical=0.85,    # 85% memory usage critical
-    cpu_warning=0.8,         # 80% CPU usage warning
-    cpu_critical=0.9,        # 90% CPU usage critical
-    disk_warning=0.8,        # 80% disk usage warning
-    disk_critical=0.9,       # 90% disk usage critical
+    memory_warning=0.7,  # 70% memory usage warning
+    memory_critical=0.85,  # 85% memory usage critical
+    cpu_warning=0.8,  # 80% CPU usage warning
+    cpu_critical=0.9,  # 90% CPU usage critical
+    disk_warning=0.8,  # 80% disk usage warning
+    disk_critical=0.9,  # 90% disk usage critical
 )
 
 orchestrator = WorkflowOrchestrator(
@@ -209,8 +211,7 @@ checkpoint_id = await orchestrator._create_checkpoint(CheckpointType.MANUAL)
 
 # Resume from checkpoint
 result = await orchestrator.execute_workflow(
-    pipeline_instance,
-    resume_from_checkpoint=checkpoint_id
+    pipeline_instance, resume_from_checkpoint=checkpoint_id
 )
 
 # List checkpoints
@@ -220,9 +221,7 @@ for cp in checkpoints:
 
 # Cleanup old checkpoints
 deleted_count = orchestrator.checkpoint_manager.cleanup_old_checkpoints(
-    max_age_days=7,
-    max_count=50,
-    keep_milestone=True
+    max_age_days=7, max_count=50, keep_milestone=True
 )
 ```
 
@@ -301,9 +300,11 @@ The orchestration system publishes events throughout execution:
 ```python
 from evoseal.core.events import event_bus
 
+
 @event_bus.subscribe("orchestration.checkpoint_created")
 async def on_checkpoint_created(event):
     print(f"Checkpoint created: {event.data['checkpoint_id']}")
+
 
 @event_bus.subscribe("orchestration.recovery_initiated")
 async def on_recovery_initiated(event):
@@ -377,6 +378,7 @@ async def custom_recovery_action(error, execution_context, iteration, step_id):
     logger.info(f"Attempting custom recovery for {error}")
     # Implement custom recovery logic
     return True  # Return True if recovery successful
+
 
 # Add to recovery strategy
 recovery_strategy.custom_recovery_actions.append(custom_recovery_action)
@@ -508,7 +510,8 @@ Enable detailed logging:
 
 ```python
 import logging
-logging.getLogger('evoseal.core.orchestration').setLevel(logging.DEBUG)
+
+logging.getLogger("evoseal.core.orchestration").setLevel(logging.DEBUG)
 ```
 
 Check orchestrator status:

--- a/docs/architecture/local_coevolution.md
+++ b/docs/architecture/local_coevolution.md
@@ -84,11 +84,13 @@ cannot silently corrupt itself:
 import asyncio
 from evoseal.prompt_evolution import CoevolutionManager, TaskSpec
 
+
 async def main():
     mgr = CoevolutionManager()  # discovers coder+reviewer models from Ollama
     task = TaskSpec(id="demo", description="Write median(nums) for a list of numbers")
     result = await mgr.run_cycle(task)
     print(result.reason, result.score_before, "->", result.score_after)
+
 
 asyncio.run(main())
 ```

--- a/docs/examples/quickstart.md
+++ b/docs/examples/quickstart.md
@@ -72,6 +72,7 @@ def custom_fitness(solution):
     # ... evaluation logic ...
     return score
 
+
 evoseal = EVOSEAL(fitness_function=custom_fitness)
 ```
 

--- a/docs/examples/self_improvement_walkthrough.md
+++ b/docs/examples/self_improvement_walkthrough.md
@@ -98,14 +98,9 @@ class CandidateSelector:
         )
         fitness_range = self.fitness_scores.max() - self.fitness_scores.min() + 1e-8
         mean_fitness = self.fitness_scores.mean()
-        variance_bonus = 1.0 - np.abs(self.fitness_scores - mean_fitness) / (
-            fitness_range
-        )
+        variance_bonus = 1.0 - np.abs(self.fitness_scores - mean_fitness) / (fitness_range)
 
-        composite_score = (
-            fitness_norm * (1 - variance_weight) +
-            variance_bonus * variance_weight
-        )
+        composite_score = fitness_norm * (1 - variance_weight) + variance_bonus * variance_weight
         indices = np.argsort(composite_score)[-k:]
         return sorted(indices)
 

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -85,9 +85,10 @@ integration:
 **Example usage:**
 ```python
 from evoseal.models.system_config import SystemConfig
-config = SystemConfig.from_yaml('configs/evoseal.yaml')
+
+config = SystemConfig.from_yaml("configs/evoseal.yaml")
 config.validate()  # Raises if required sections are missing
-max_iters = config.get('dgm.max_iterations', 100)
+max_iters = config.get("dgm.max_iterations", 100)
 ```
 
 ### Environment-Specific Configuration

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -125,16 +125,14 @@ Use fixtures for common test setup:
 ```python
 import pytest
 
+
 @pytest.fixture
 def sample_config():
-    return {
-        'population_size': 100,
-        'mutation_rate': 0.1,
-        'crossover_rate': 0.8
-    }
+    return {"population_size": 100, "mutation_rate": 0.1, "crossover_rate": 0.8}
+
 
 def test_evolution_config(sample_config):
-    assert sample_config['population_size'] == 100
+    assert sample_config["population_size"] == 100
 ```
 
 ## Test Coverage

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -84,7 +84,8 @@ This guide provides solutions to common issues you might encounter while using o
 4. Use CPU instead of GPU:
    ```python
    import os
-   os.environ['CUDA_VISIBLE_DEVICES'] = ''
+
+   os.environ["CUDA_VISIBLE_DEVICES"] = ""
    ```
 
 ## Performance Problems
@@ -114,6 +115,7 @@ This guide provides solutions to common issues you might encounter while using o
 1. Clear unused variables:
    ```python
    import gc
+
    gc.collect()
    ```
 
@@ -138,6 +140,7 @@ This guide provides solutions to common issues you might encounter while using o
 1. Add delays between requests:
    ```python
    import time
+
    time.sleep(1)  # 1 second delay
    ```
 
@@ -146,10 +149,11 @@ This guide provides solutions to common issues you might encounter while using o
    import time
    import random
 
+
    def exponential_backoff(retries):
        base_delay = 1  # seconds
        max_delay = 60  # seconds
-       delay = min(max_delay, (2 ** retries) * base_delay + random.uniform(0, 1))
+       delay = min(max_delay, (2**retries) * base_delay + random.uniform(0, 1))
        time.sleep(delay)
    ```
 
@@ -176,13 +180,16 @@ This guide provides solutions to common issues you might encounter while using o
 
 ```python
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
 ```
 
 ### 2. Use pdb for Debugging
 
 ```python
-import pdb; pdb.set_trace()  # Add this line where you want to start debugging
+import pdb
+
+pdb.set_trace()  # Add this line where you want to start debugging
 ```
 
 ### 3. Check Intermediate Results

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -207,13 +207,14 @@ import pytest
 from unittest.mock import Mock, patch
 from evoseal.core import EvolutionPipeline
 
+
 class TestEvolutionPipeline:
     def test_initialization(self):
         """Test pipeline initialization."""
         pipeline = EvolutionPipeline()
         assert pipeline is not None
 
-    @patch('evoseal.core.evolution_pipeline.SomeExternalService')
+    @patch("evoseal.core.evolution_pipeline.SomeExternalService")
     def test_with_mock(self, mock_service):
         """Test with mocked external dependency."""
         mock_service.return_value.process.return_value = "success"
@@ -306,13 +307,18 @@ pip freeze > requirements/pinned_requirements.txt
 ```python
 # Enable debug logging
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
 
 # Use debugger
-import pdb; pdb.set_trace()
+import pdb
+
+pdb.set_trace()
 
 # Or use ipdb for better experience
-import ipdb; ipdb.set_trace()
+import ipdb
+
+ipdb.set_trace()
 ```
 
 ### Common Debugging Scenarios

--- a/docs/integration/adapters.md
+++ b/docs/integration/adapters.md
@@ -138,7 +138,7 @@ adapter = create_openevolve_adapter(
             "request_timeout": 300,
             "poll_interval": 2.0,
             "job": {"initial_program": "..."},
-        }
+        },
     },
 )
 ```

--- a/docs/safety/cost_and_budget_spec.md
+++ b/docs/safety/cost_and_budget_spec.md
@@ -152,6 +152,7 @@ class BudgetConfig(BaseModel):
     max_tokens_per_cycle: int = 15_000
     max_tokens_per_epoch: int = 20_000
 
+
 # Add to Settings:
 # budget: BudgetConfig = Field(default_factory=BudgetConfig)
 ```
@@ -183,7 +184,7 @@ live in the caller so it can short-circuit the full cycle before DGM is invoked.
 ```python
 # In evolution_pipeline.py — cycle loop (caller of safety_integration.execute_safe_evolution_step)
 current_tokens = self.budget_tracker.tokens_consumed_this_run  # added by task 2.9
-budget = self.config.budget.max_tokens_per_run                 # added by task 2.10
+budget = self.config.budget.max_tokens_per_run  # added by task 2.10
 
 if current_tokens >= budget:
     log.warning(f"Budget exhausted: {current_tokens} / {budget} tokens")
@@ -202,13 +203,15 @@ started.
 ```python
 # In evolution_pipeline.py — immediately after DGM.generate() returns
 pre_call_tokens = self.budget_tracker.tokens_consumed_this_run  # snapshot taken before call
-call_tokens = dgm_response.usage.total_tokens                   # actual tokens from API response
+call_tokens = dgm_response.usage.total_tokens  # actual tokens from API response
 post_call_tokens = pre_call_tokens + call_tokens
 overage = post_call_tokens - budget  # raw overage over the run budget; 0 if still under budget
 
 if overage > config.budget.stop_tolerance_tokens:
-    log.error(f"Token overage {overage} exceeds tolerance {config.budget.stop_tolerance_tokens}; "
-              f"cumulative: {post_call_tokens} / {budget}")
+    log.error(
+        f"Token overage {overage} exceeds tolerance {config.budget.stop_tolerance_tokens}; "
+        f"cumulative: {post_call_tokens} / {budget}"
+    )
     # Current variant is rejected; loop stops
     return {"status": "BUDGET_EXHAUSTION_HARD", "reason": "overage tolerance exceeded"}
 ```
@@ -219,8 +222,10 @@ When consumption reaches `warn_at_percent_of_budget` of the total budget, a warn
 
 ```python
 if current_tokens >= (budget * warn_at_percent_of_budget / 100):
-    log.warning(f"Budget {warn_at_percent_of_budget}% consumed: {current_tokens} / {budget} tokens. "
-                f"Approximately {estimated_cycles_remaining} cycles remain.")
+    log.warning(
+        f"Budget {warn_at_percent_of_budget}% consumed: {current_tokens} / {budget} tokens. "
+        f"Approximately {estimated_cycles_remaining} cycles remain."
+    )
 ```
 
 The warning includes an **estimated cycles remaining** based on the average cost per cycle observed so far.

--- a/docs/safety/enhanced_rollback_logic.md
+++ b/docs/safety/enhanced_rollback_logic.md
@@ -82,13 +82,12 @@ The enhanced rollback logic supports new configuration options:
 ```python
 rollback_config = {
     # Existing options
-    'auto_rollback_enabled': True,
-    'rollback_threshold': 0.1,
-    'max_rollback_attempts': 3,
-
+    "auto_rollback_enabled": True,
+    "rollback_threshold": 0.1,
+    "max_rollback_attempts": 3,
     # New options for enhanced features
-    'enable_cascading_rollback': True,          # Enable cascading rollback
-    'enable_rollback_failure_recovery': True,   # Enable failure recovery
+    "enable_cascading_rollback": True,  # Enable cascading rollback
+    "enable_rollback_failure_recovery": True,  # Enable failure recovery
 }
 ```
 
@@ -107,7 +106,7 @@ success = rollback_manager.rollback_to_version("v2.0", "manual_rollback")
 ```python
 # Attempt cascading rollback with up to 3 attempts
 result = rollback_manager.cascading_rollback("failed_v3.0", max_attempts=3)
-if result['success']:
+if result["success"]:
     print(f"Cascaded to: {result['final_version']}")
     print(f"Chain: {result['rollback_chain']}")
 ```
@@ -116,7 +115,7 @@ if result['success']:
 ```python
 # Handle rollback failures with recovery strategies
 recovery = rollback_manager.handle_rollback_failure("failed_v2.0", "Checkpoint corrupted")
-if recovery['success']:
+if recovery["success"]:
     print(f"Recovered using: {recovery['recovery_strategy']}")
 ```
 
@@ -124,10 +123,12 @@ if recovery['success']:
 ```python
 from evoseal.core.events import subscribe, EventType
 
+
 @subscribe(EventType.ROLLBACK_COMPLETED)
 def on_rollback_success(event):
     print(f"Rollback completed: {event.data['version_id']}")
     print(f"Verification passed: {event.data['verification_passed']}")
+
 
 @subscribe(EventType.CASCADING_ROLLBACK_COMPLETED)
 def on_cascading_success(event):

--- a/docs/safety/evolution_pipeline_safety_integration.md
+++ b/docs/safety/evolution_pipeline_safety_integration.md
@@ -72,34 +72,26 @@ config = EvolutionConfig(
         "storage_path": "metrics/",
         "thresholds": {
             "accuracy": {"threshold": 0.05, "direction": "decrease"},
-            "performance": {"threshold": 0.2, "direction": "increase"}
-        }
+            "performance": {"threshold": 0.2, "direction": "increase"},
+        },
     },
-    validation_config={
-        "enabled": True,
-        "min_improvement_score": 70.0,
-        "confidence_level": 0.95
-    },
-
+    validation_config={"enabled": True, "min_improvement_score": 70.0, "confidence_level": 0.95},
     # Safety integration configuration
     safety_config={
         "auto_checkpoint": True,
         "auto_rollback": True,
         "safety_checks_enabled": True,
-
         "checkpoints": {
             "checkpoint_dir": "checkpoints/",
             "max_checkpoints": 50,
             "auto_cleanup": True,
-            "compression_enabled": True
+            "compression_enabled": True,
         },
-
         "rollback": {
             "enable_rollback_failure_recovery": True,
             "max_rollback_attempts": 3,
-            "rollback_timeout": 30
+            "rollback_timeout": 30,
         },
-
         "regression": {
             "regression_threshold": 0.1,
             "enable_statistical_analysis": True,
@@ -107,10 +99,10 @@ config = EvolutionConfig(
             "metric_thresholds": {
                 "accuracy": {"threshold": 0.05, "direction": "decrease"},
                 "performance": {"threshold": 0.2, "direction": "increase"},
-                "memory_usage": {"threshold": 0.3, "direction": "increase"}
-            }
-        }
-    }
+                "memory_usage": {"threshold": 0.3, "direction": "increase"},
+            },
+        },
+    },
 )
 
 # Create pipeline with safety integration
@@ -126,23 +118,13 @@ safety_config = {
     "auto_checkpoint": True,
     "auto_rollback": True,
     "safety_checks_enabled": True,
-
-    "checkpoints": {
-        "checkpoint_dir": "checkpoints/",
-        "max_checkpoints": 50,
-        "auto_cleanup": True
-    },
-
-    "rollback": {
-        "enable_rollback_failure_recovery": True,
-        "max_rollback_attempts": 3
-    },
-
+    "checkpoints": {"checkpoint_dir": "checkpoints/", "max_checkpoints": 50, "auto_cleanup": True},
+    "rollback": {"enable_rollback_failure_recovery": True, "max_rollback_attempts": 3},
     "regression": {
         "regression_threshold": 0.1,
         "enable_statistical_analysis": True,
-        "enable_anomaly_detection": True
-    }
+        "enable_anomaly_detection": True,
+    },
 }
 
 safety_integration = SafetyIntegration(safety_config, metrics_tracker)
@@ -156,6 +138,7 @@ safety_integration = SafetyIntegration(safety_config, metrics_tracker)
 import asyncio
 from evoseal.core.evolution_pipeline import EvolutionPipeline, EvolutionConfig
 
+
 async def run_safe_evolution():
     # Create configuration
     config = EvolutionConfig(
@@ -164,8 +147,8 @@ async def run_safe_evolution():
         safety_config={
             "auto_checkpoint": True,
             "auto_rollback": True,
-            "safety_checks_enabled": True
-        }
+            "safety_checks_enabled": True,
+        },
     )
 
     # Create pipeline
@@ -173,9 +156,7 @@ async def run_safe_evolution():
 
     # Run safety-aware evolution cycle
     results = await pipeline.run_evolution_cycle_with_safety(
-        iterations=5,
-        enable_checkpoints=True,
-        enable_auto_rollback=True
+        iterations=5, enable_checkpoints=True, enable_auto_rollback=True
     )
 
     # Analyze results
@@ -186,6 +167,7 @@ async def run_safe_evolution():
     print(f"Successful iterations: {successful_iterations}/{len(results)}")
     print(f"Accepted versions: {accepted_versions}")
     print(f"Rollbacks performed: {rollbacks_performed}")
+
 
 # Run the evolution
 asyncio.run(run_safe_evolution())

--- a/docs/safety/regression_detector_interface.md
+++ b/docs/safety/regression_detector_interface.md
@@ -23,10 +23,10 @@ Establishes a baseline from a specific version's metrics.
 
 ```python
 # Establish a production baseline
-success = detector.establish_baseline('v1.0', 'production_baseline')
+success = detector.establish_baseline("v1.0", "production_baseline")
 
 # Establish a development baseline
-success = detector.establish_baseline('v1.1-dev', 'dev_baseline')
+success = detector.establish_baseline("v1.1-dev", "dev_baseline")
 ```
 
 **Parameters:**
@@ -40,7 +40,7 @@ success = detector.establish_baseline('v1.1-dev', 'dev_baseline')
 Retrieves baseline data by name.
 
 ```python
-baseline = detector.get_baseline('production_baseline')
+baseline = detector.get_baseline("production_baseline")
 if baseline:
     print(f"Baseline version: {baseline['version_id']}")
     print(f"Metrics count: {len(baseline['metrics'])}")
@@ -61,7 +61,7 @@ for baseline in baselines:
 Compares a version against an established baseline.
 
 ```python
-has_regression, details = detector.compare_against_baseline('v1.2', 'production_baseline')
+has_regression, details = detector.compare_against_baseline("v1.2", "production_baseline")
 if has_regression:
     print(f"Regressions detected in {len(details)} metrics")
 ```
@@ -73,7 +73,7 @@ if has_regression:
 Core regression detection between two specific versions.
 
 ```python
-has_regression, details = detector.detect_regression('v1.0', 'v1.1')
+has_regression, details = detector.detect_regression("v1.0", "v1.1")
 ```
 
 #### `run_regression_analysis(version_id, baseline_name="default", trigger_alerts=True) -> Dict[str, Any]`
@@ -81,7 +81,7 @@ has_regression, details = detector.detect_regression('v1.0', 'v1.1')
 Runs comprehensive regression analysis with optional alert triggering.
 
 ```python
-analysis = detector.run_regression_analysis('v1.2', 'production_baseline')
+analysis = detector.run_regression_analysis("v1.2", "production_baseline")
 print(f"Recommendation: {analysis['summary']['recommendation']}")
 ```
 
@@ -94,6 +94,7 @@ Registers a callback function to be called when regressions are detected.
 ```python
 def email_alert(regression_data):
     send_email_to_team(f"Regression detected: {len(regression_data)} metrics affected")
+
 
 detector.register_alert_callback(email_alert)
 ```
@@ -114,12 +115,12 @@ Configures integration with testing frameworks.
 
 ```python
 pytest_config = {
-    'test_command': 'pytest tests/',
-    'coverage_threshold': 0.80,
-    'performance_tests': True
+    "test_command": "pytest tests/",
+    "coverage_threshold": 0.80,
+    "performance_tests": True,
 }
 
-success = detector.integrate_with_test_framework('pytest', pytest_config)
+success = detector.integrate_with_test_framework("pytest", pytest_config)
 ```
 
 **Supported Frameworks:**
@@ -135,36 +136,33 @@ The RegressionDetector accepts comprehensive configuration:
 ```python
 config = {
     # Basic settings
-    'regression_threshold': 0.05,  # 5% default threshold
-    'baseline_storage_path': './baselines.json',
-
+    "regression_threshold": 0.05,  # 5% default threshold
+    "baseline_storage_path": "./baselines.json",
     # Alert system
-    'alert_enabled': True,
-    'auto_baseline_update': False,
-
+    "alert_enabled": True,
+    "auto_baseline_update": False,
     # Monitored metrics
-    'monitored_metrics': [
-        'success_rate', 'accuracy', 'duration_sec',
-        'memory_mb', 'error_rate', 'pass_rate'
+    "monitored_metrics": [
+        "success_rate",
+        "accuracy",
+        "duration_sec",
+        "memory_mb",
+        "error_rate",
+        "pass_rate",
     ],
-
     # Per-metric thresholds
-    'metric_thresholds': {
-        'success_rate': {'regression': 0.03, 'critical': 0.10},
-        'accuracy': {'regression': 0.05, 'critical': 0.15},
-        'duration_sec': {'regression': 0.20, 'critical': 0.50},
-        'memory_mb': {'regression': 0.15, 'critical': 0.30},
-        'error_rate': {'regression': 0.50, 'critical': 1.00},
-        'pass_rate': {'regression': 0.05, 'critical': 0.15}
+    "metric_thresholds": {
+        "success_rate": {"regression": 0.03, "critical": 0.10},
+        "accuracy": {"regression": 0.05, "critical": 0.15},
+        "duration_sec": {"regression": 0.20, "critical": 0.50},
+        "memory_mb": {"regression": 0.15, "critical": 0.30},
+        "error_rate": {"regression": 0.50, "critical": 1.00},
+        "pass_rate": {"regression": 0.05, "critical": 0.15},
     },
-
     # Testing framework integration
-    'test_framework_integration': {
-        'pytest': {
-            'test_command': 'pytest tests/',
-            'coverage_threshold': 0.80
-        }
-    }
+    "test_framework_integration": {
+        "pytest": {"test_command": "pytest tests/", "coverage_threshold": 0.80}
+    },
 }
 
 detector = RegressionDetector(metrics_tracker, config)
@@ -205,6 +203,7 @@ Published when a new baseline is established.
 def handle_baseline_established(event_data):
     print(f"Baseline {event_data['baseline_name']} established from v{event_data['version_id']}")
 
+
 subscribe(EventType.BASELINE_ESTABLISHED, handle_baseline_established)
 ```
 
@@ -213,9 +212,10 @@ Published when regressions are detected and alerts are triggered.
 
 ```python
 def handle_regression_alert(event_data):
-    critical_count = len(event_data['critical_regressions'])
+    critical_count = len(event_data["critical_regressions"])
     if critical_count > 0:
         initiate_emergency_response()
+
 
 subscribe(EventType.REGRESSION_ALERT, handle_regression_alert)
 ```
@@ -236,14 +236,16 @@ Add custom metrics through configuration:
 
 ```python
 config = {
-    'monitored_metrics': [
-        'success_rate', 'accuracy',  # Standard metrics
-        'custom_score', 'business_kpi'  # Custom metrics
+    "monitored_metrics": [
+        "success_rate",
+        "accuracy",  # Standard metrics
+        "custom_score",
+        "business_kpi",  # Custom metrics
     ],
-    'metric_thresholds': {
-        'custom_score': {'regression': 0.10, 'critical': 0.25},
-        'business_kpi': {'regression': 0.05, 'critical': 0.15}
-    }
+    "metric_thresholds": {
+        "custom_score": {"regression": 0.10, "critical": 0.25},
+        "business_kpi": {"regression": 0.05, "critical": 0.15},
+    },
 }
 ```
 
@@ -256,14 +258,14 @@ config = {
 detector = RegressionDetector(metrics_tracker, config)
 
 # Establish baseline from stable release
-detector.establish_baseline('v1.0-stable', 'ci_baseline')
+detector.establish_baseline("v1.0-stable", "ci_baseline")
 
 # Test new build
-analysis = detector.run_regression_analysis('build-123', 'ci_baseline')
+analysis = detector.run_regression_analysis("build-123", "ci_baseline")
 
-if analysis['summary']['recommendation'] == 'rollback_required':
+if analysis["summary"]["recommendation"] == "rollback_required":
     trigger_rollback()
-elif analysis['summary']['recommendation'] == 'review_required':
+elif analysis["summary"]["recommendation"] == "review_required":
     notify_development_team()
 ```
 
@@ -271,7 +273,7 @@ elif analysis['summary']['recommendation'] == 'review_required':
 
 ```python
 # Compare A/B test variants
-has_regression, details = detector.detect_regression('variant_a', 'variant_b')
+has_regression, details = detector.detect_regression("variant_a", "variant_b")
 
 if has_regression:
     # Analyze which variant performs better
@@ -288,12 +290,9 @@ detector.register_alert_callback(create_incident_ticket)
 
 # Continuous monitoring
 for new_deployment in production_deployments:
-    analysis = detector.run_regression_analysis(
-        new_deployment.version,
-        'production_baseline'
-    )
+    analysis = detector.run_regression_analysis(new_deployment.version, "production_baseline")
 
-    if analysis['has_regression']:
+    if analysis["has_regression"]:
         handle_production_regression(analysis)
 ```
 
@@ -329,16 +328,16 @@ for new_deployment in production_deployments:
 
 #### Baseline Not Found
 ```python
-baseline = detector.get_baseline('missing_baseline')
+baseline = detector.get_baseline("missing_baseline")
 if not baseline:
     # Establish a new baseline
-    detector.establish_baseline('v1.0', 'missing_baseline')
+    detector.establish_baseline("v1.0", "missing_baseline")
 ```
 
 #### No Metrics Available
 ```python
-has_regression, details = detector.compare_against_baseline('v1.1')
-if 'error' in details:
+has_regression, details = detector.compare_against_baseline("v1.1")
+if "error" in details:
     logger.error(f"Metrics comparison failed: {details['error']}")
     # Check metrics_tracker configuration
 ```

--- a/docs/safety/rollback_manager_interface.md
+++ b/docs/safety/rollback_manager_interface.md
@@ -41,7 +41,7 @@ mock_version_manager.working_dir = "/home/user"  # Dangerous!
 # → Creates: /path/to/project/.evoseal/rollback_target
 # → Logs: "Using safe rollback directory... Configure proper working_dir"
 # → Rollback succeeds safely without deleting codebase
-result = rollback_manager.rollback_to_version('v1.0', 'safety_test')
+result = rollback_manager.rollback_to_version("v1.0", "safety_test")
 # result = True (success with safety)
 ```
 
@@ -71,9 +71,9 @@ python tests/safety/verify_rollback_safety.py
 ```python
 # Example policy configuration
 policy = {
-    'auto_rollback_enabled': True,
-    'rollback_threshold': 0.05,  # 5% regression threshold
-    'max_rollback_attempts': 3
+    "auto_rollback_enabled": True,
+    "rollback_threshold": 0.05,  # 5% regression threshold
+    "max_rollback_attempts": 3,
 }
 rollback_manager.set_rollback_policy(policy)
 ```
@@ -86,9 +86,7 @@ rollback_manager.set_rollback_policy(policy)
 ```python
 # Authorized rollback
 result = rollback_manager.initiate_rollback(
-    'stable_v1.0',
-    authorization_token='admin',
-    reason='production_issue_fix'
+    "stable_v1.0", authorization_token="admin", reason="production_issue_fix"
 )
 ```
 
@@ -101,9 +99,9 @@ result = rollback_manager.initiate_rollback(
 ```python
 # Configure rollback triggers
 triggers = {
-    'auto_rollback_enabled': True,
-    'metrics_regression': {'threshold': 0.08},
-    'max_attempts': 4
+    "auto_rollback_enabled": True,
+    "metrics_regression": {"threshold": 0.08},
+    "max_attempts": 4,
 }
 rollback_manager.configure_rollback_triggers(triggers)
 ```
@@ -123,8 +121,7 @@ rollback_manager.configure_rollback_triggers(triggers)
 ```python
 # Emergency rollback
 result = rollback_manager.emergency_rollback(
-    authorization_token='emergency_admin',
-    reason='critical_system_failure'
+    authorization_token="emergency_admin", reason="critical_system_failure"
 )
 ```
 
@@ -222,9 +219,7 @@ rollback_manager = RollbackManager(config, checkpoint_manager)
 
 # Perform authorized rollback
 result = rollback_manager.initiate_rollback(
-    'stable_v1.0',
-    authorization_token='admin',
-    reason='performance_regression'
+    "stable_v1.0", authorization_token="admin", reason="performance_regression"
 )
 ```
 
@@ -232,26 +227,25 @@ result = rollback_manager.initiate_rollback(
 ```python
 # Configure auto-rollback
 policy = {
-    'auto_rollback_enabled': True,
-    'rollback_threshold': 0.1,  # 10% threshold
-    'max_rollback_attempts': 5
+    "auto_rollback_enabled": True,
+    "rollback_threshold": 0.1,  # 10% threshold
+    "max_rollback_attempts": 5,
 }
 rollback_manager.set_rollback_policy(policy)
 
 # Auto-rollback will trigger on test failures
 test_results = [
-    {'name': 'test_accuracy', 'status': 'fail'},
-    {'name': 'test_performance', 'status': 'pass'}
+    {"name": "test_accuracy", "status": "fail"},
+    {"name": "test_performance", "status": "pass"},
 ]
-rollback_manager.auto_rollback_on_failure('experimental_v3.0', test_results)
+rollback_manager.auto_rollback_on_failure("experimental_v3.0", test_results)
 ```
 
 ### Emergency Rollback
 ```python
 # Emergency rollback with automatic target selection
 result = rollback_manager.emergency_rollback(
-    authorization_token='emergency_admin',
-    reason='critical_production_failure'
+    authorization_token="emergency_admin", reason="critical_production_failure"
 )
 ```
 

--- a/docs/safety/rollback_safety.md
+++ b/docs/safety/rollback_safety.md
@@ -134,7 +134,7 @@ version_manager.working_dir = "/home/user"  # DANGEROUS!
 # 4. Validates safe directory in _validate_rollback_target()
 # 5. Proceeds with rollback safely
 
-result = rollback_manager.rollback_to_version('stable_v1.0')
+result = rollback_manager.rollback_to_version("stable_v1.0")
 # result = True (rollback succeeded safely)
 
 # Your original codebase is NEVER touched!
@@ -189,8 +189,8 @@ For production deployment, configure a proper working directory:
 ```python
 # Recommended: Configure dedicated rollback directory
 config = {
-    'version_manager': {
-        'working_dir': '/opt/evoseal/rollback_workspace'  # Safe, isolated directory
+    "version_manager": {
+        "working_dir": "/opt/evoseal/rollback_workspace"  # Safe, isolated directory
     }
 }
 

--- a/docs/safety/safety_validation.md
+++ b/docs/safety/safety_validation.md
@@ -81,11 +81,7 @@ Manages version checkpoints with comprehensive metadata storage.
 from evoseal.core.checkpoint_manager import CheckpointManager
 
 # Initialize checkpoint manager
-config = {
-    "checkpoint_dir": "/path/to/checkpoints",
-    "max_checkpoints": 50,
-    "auto_cleanup": True
-}
+config = {"checkpoint_dir": "/path/to/checkpoints", "max_checkpoints": 50, "auto_cleanup": True}
 checkpoint_manager = CheckpointManager(config)
 
 # Create checkpoint
@@ -124,10 +120,7 @@ Provides manual and automatic rollback capabilities with history tracking.
 from evoseal.core.rollback_manager import RollbackManager
 
 # Initialize rollback manager
-config = {
-    "rollback_history_file": "/path/to/history.json",
-    "max_history_entries": 1000
-}
+config = {"rollback_history_file": "/path/to/history.json", "max_history_entries": 1000}
 rollback_manager = RollbackManager(config, checkpoint_manager, version_manager)
 
 # Manual rollback
@@ -172,8 +165,8 @@ config = {
     "regression_threshold": 0.05,  # 5% default threshold
     "metric_thresholds": {
         "success_rate": {"regression": -0.05, "critical": -0.1},
-        "duration_sec": {"regression": 0.1, "critical": 0.25}
-    }
+        "duration_sec": {"regression": 0.1, "critical": 0.25},
+    },
 }
 regression_detector = RegressionDetector(config, metrics_tracker)
 
@@ -236,7 +229,7 @@ config = {
     "regression": {...},
     "auto_checkpoint": True,
     "auto_rollback": True,
-    "safety_checks_enabled": True
+    "safety_checks_enabled": True,
 }
 safety_integration = SafetyIntegration(config, metrics_tracker, version_manager)
 
@@ -245,13 +238,11 @@ result = safety_integration.execute_safe_evolution_step(
     current_version_id="v1.0",
     new_version_data=version_data,
     new_version_id="v1.1",
-    test_results=test_results
+    test_results=test_results,
 )
 
 # Validate version safety
-validation = safety_integration.validate_version_safety(
-    "v1.0", "v1.1", test_results
-)
+validation = safety_integration.validate_version_safety("v1.0", "v1.1", test_results)
 
 # Get safety status
 status = safety_integration.get_safety_status()
@@ -268,19 +259,13 @@ from evoseal.core.evolution_pipeline import EvolutionPipeline
 
 # Initialize pipeline with safety configuration
 config = PipelineConfig(
-    safety_config={
-        "auto_checkpoint": True,
-        "auto_rollback": True,
-        "regression_threshold": 0.05
-    }
+    safety_config={"auto_checkpoint": True, "auto_rollback": True, "regression_threshold": 0.05}
 )
 pipeline = EvolutionPipeline(config)
 
 # Run evolution with safety mechanisms
 results = await pipeline.run_evolution_cycle_with_safety(
-    iterations=10,
-    enable_checkpoints=True,
-    enable_auto_rollback=True
+    iterations=10, enable_checkpoints=True, enable_auto_rollback=True
 )
 ```
 
@@ -304,17 +289,15 @@ safety_config = {
         "checkpoint_dir": "./checkpoints",
         "max_checkpoints": 50,
         "auto_cleanup": True,
-        "compression": True
+        "compression": True,
     },
-
     # Rollback configuration
     "rollback": {
         "rollback_history_file": "./rollback_history.json",
         "max_history_entries": 1000,
         "auto_rollback_enabled": True,
-        "rollback_timeout": 300
+        "rollback_timeout": 300,
     },
-
     # Regression detection configuration
     "regression": {
         "regression_threshold": 0.05,
@@ -323,22 +306,19 @@ safety_config = {
             "duration_sec": {"regression": 0.1, "critical": 0.25},
             "memory_mb": {"regression": 0.1, "critical": 0.3},
             "cpu_percent": {"regression": 0.1, "critical": 0.3},
-
             # Quality metrics (higher is better)
             "success_rate": {"regression": -0.05, "critical": -0.1},
             "accuracy": {"regression": -0.05, "critical": -0.1},
             "precision": {"regression": -0.05, "critical": -0.1},
             "recall": {"regression": -0.05, "critical": -0.1},
-
             # Error metrics (lower is better)
-            "error_rate": {"regression": 0.05, "critical": 0.1}
-        }
+            "error_rate": {"regression": 0.05, "critical": 0.1},
+        },
     },
-
     # Safety integration settings
     "auto_checkpoint": True,
     "auto_rollback": True,
-    "safety_checks_enabled": True
+    "safety_checks_enabled": True,
 }
 ```
 
@@ -422,7 +402,8 @@ Enable detailed logging for debugging:
 
 ```python
 import logging
-logging.getLogger('evoseal.core.safety').setLevel(logging.DEBUG)
+
+logging.getLogger("evoseal.core.safety").setLevel(logging.DEBUG)
 ```
 
 ## API Reference

--- a/docs/safety/statistical_regression_detection.md
+++ b/docs/safety/statistical_regression_detection.md
@@ -20,14 +20,14 @@ The system calculates confidence intervals to determine statistical significance
 
 ```python
 config = {
-    'statistical_analysis': {
-        'confidence_level': 0.95,  # 95% confidence intervals
-        'min_samples': 3,          # Minimum samples for analysis
+    "statistical_analysis": {
+        "confidence_level": 0.95,  # 95% confidence intervals
+        "min_samples": 3,  # Minimum samples for analysis
     }
 }
 
 # Analyze metric statistics
-stats = detector.analyze_metric_statistics('success_rate', values)
+stats = detector.analyze_metric_statistics("success_rate", values)
 print(f"95% CI: {stats['confidence_interval']}")
 ```
 
@@ -42,7 +42,7 @@ print(f"95% CI: {stats['confidence_interval']}")
 Linear regression-based trend analysis identifies patterns over time:
 
 ```python
-trend = stats['trend_analysis']
+trend = stats["trend_analysis"]
 print(f"Trend: {trend['direction']} ({trend['strength']})")
 print(f"Slope: {trend['slope']:.6f}")
 print(f"R²: {trend['r_squared']:.4f}")
@@ -72,13 +72,10 @@ Identifies outliers based on standard deviations from the mean:
 
 ```python
 config = {
-    'statistical_analysis': {
-        'outlier_threshold': 2.0,  # 2 standard deviations
+    "statistical_analysis": {
+        "outlier_threshold": 2.0,  # 2 standard deviations
     },
-    'anomaly_detection': {
-        'algorithms': ['zscore'],
-        'sensitivity': 'medium'
-    }
+    "anomaly_detection": {"algorithms": ["zscore"], "sensitivity": "medium"},
 }
 ```
 
@@ -93,7 +90,7 @@ Robust outlier detection using quartile-based bounds:
 
 ```python
 # IQR method configuration
-config['anomaly_detection']['algorithms'].append('iqr')
+config["anomaly_detection"]["algorithms"].append("iqr")
 ```
 
 **IQR Method:**
@@ -108,9 +105,9 @@ Behavioral pattern recognition for sudden changes:
 
 ```python
 config = {
-    'anomaly_detection': {
-        'pattern_recognition': True,
-        'sensitivity': 'medium'  # low, medium, high
+    "anomaly_detection": {
+        "pattern_recognition": True,
+        "sensitivity": "medium",  # low, medium, high
     }
 }
 ```
@@ -131,12 +128,12 @@ The enhanced regression detection combines multiple analysis methods:
 
 ```python
 enhanced_analysis = detector.get_statistical_regression_analysis(
-    'success_rate', old_value, new_value
+    "success_rate", old_value, new_value
 )
 
 # Check statistical significance
-stat_sig = enhanced_analysis['statistical_significance']
-if not stat_sig['within_confidence_interval']:
+stat_sig = enhanced_analysis["statistical_significance"]
+if not stat_sig["within_confidence_interval"]:
     print("Statistically significant change detected!")
 ```
 
@@ -150,7 +147,7 @@ if not stat_sig['within_confidence_interval']:
 Provides context based on historical performance:
 
 ```python
-hist_context = enhanced_analysis['historical_context']
+hist_context = enhanced_analysis["historical_context"]
 print(f"Historical percentile: {hist_context['percentile_rank']:.1f}%")
 print(f"Deviation from mean: {hist_context['deviation_from_mean']:+.4f}")
 ```
@@ -165,9 +162,9 @@ print(f"Deviation from mean: {hist_context['deviation_from_mean']:+.4f}")
 Anomaly detection results integrated into regression analysis:
 
 ```python
-anomaly_status = enhanced_analysis['anomaly_status']
-if anomaly_status['is_anomaly']:
-    for detail in anomaly_status['anomaly_details']:
+anomaly_status = enhanced_analysis["anomaly_status"]
+if anomaly_status["is_anomaly"]:
+    for detail in anomaly_status["anomaly_details"]:
         print(f"Anomaly: {detail['method']} ({detail['severity']})")
 ```
 
@@ -182,14 +179,14 @@ if anomaly_status['is_anomaly']:
 
 ```python
 statistical_config = {
-    'confidence_level': 0.95,        # Confidence interval level
-    'min_samples': 3,                # Minimum samples for analysis
-    'trend_window': 10,              # Number of points for trend analysis
-    'seasonal_period': 7,            # Period for seasonal adjustment
-    'outlier_threshold': 2.0,        # Standard deviations for outliers
-    'enable_trend_analysis': True,   # Enable trend analysis
-    'enable_anomaly_detection': True, # Enable anomaly detection
-    'enable_seasonal_adjustment': False # Enable seasonal adjustment
+    "confidence_level": 0.95,  # Confidence interval level
+    "min_samples": 3,  # Minimum samples for analysis
+    "trend_window": 10,  # Number of points for trend analysis
+    "seasonal_period": 7,  # Period for seasonal adjustment
+    "outlier_threshold": 2.0,  # Standard deviations for outliers
+    "enable_trend_analysis": True,  # Enable trend analysis
+    "enable_anomaly_detection": True,  # Enable anomaly detection
+    "enable_seasonal_adjustment": False,  # Enable seasonal adjustment
 }
 ```
 
@@ -197,10 +194,10 @@ statistical_config = {
 
 ```python
 anomaly_config = {
-    'algorithms': ['zscore', 'iqr', 'isolation'],  # Detection algorithms
-    'sensitivity': 'medium',                       # Sensitivity level
-    'adaptive_threshold': True,                    # Adaptive thresholds
-    'pattern_recognition': True                    # Pattern-based detection
+    "algorithms": ["zscore", "iqr", "isolation"],  # Detection algorithms
+    "sensitivity": "medium",  # Sensitivity level
+    "adaptive_threshold": True,  # Adaptive thresholds
+    "pattern_recognition": True,  # Pattern-based detection
 }
 ```
 
@@ -214,7 +211,7 @@ detector = RegressionDetector(config, metrics_tracker)
 
 # Analyze metric statistics
 values = [0.85, 0.87, 0.86, 0.89, 0.88, 0.90, 0.85, 0.91, 0.89, 0.92]
-stats = detector.analyze_metric_statistics('success_rate', values)
+stats = detector.analyze_metric_statistics("success_rate", values)
 
 print(f"Mean: {stats['mean']:.4f}")
 print(f"Trend: {stats['trend_analysis']['direction']}")
@@ -230,19 +227,19 @@ for version_id in version_history:
     detector.update_historical_metrics(version_id, metrics)
 
 # Detect regressions with statistical analysis
-has_regression, details = detector.detect_regression('v1.5', 'v1.6')
+has_regression, details = detector.detect_regression("v1.5", "v1.6")
 
 for metric, analysis in details.items():
     print(f"Metric: {metric}")
     print(f"Severity: {analysis['severity']}")
 
     # Statistical significance
-    if analysis['statistical_significance']:
-        sig = analysis['statistical_significance']['significance']
+    if analysis["statistical_significance"]:
+        sig = analysis["statistical_significance"]["significance"]
         print(f"Statistical significance: {sig}")
 
     # Anomaly status
-    if analysis['anomaly_status']['is_anomaly']:
+    if analysis["anomaly_status"]["is_anomaly"]:
         print("🚨 Anomaly detected!")
 ```
 
@@ -250,13 +247,13 @@ for metric, analysis in details.items():
 
 ```python
 # Analyze trends across multiple versions
-versions = ['v1.0', 'v1.1', 'v1.2', 'v1.3', 'v1.4', 'v1.5']
-values = [get_metric_value(v, 'duration_sec') for v in versions]
+versions = ["v1.0", "v1.1", "v1.2", "v1.3", "v1.4", "v1.5"]
+values = [get_metric_value(v, "duration_sec") for v in versions]
 
-stats = detector.analyze_metric_statistics('duration_sec', values)
-trend = stats['trend_analysis']
+stats = detector.analyze_metric_statistics("duration_sec", values)
+trend = stats["trend_analysis"]
 
-if trend['direction'] == 'increasing' and trend['strength'] in ['moderate', 'strong']:
+if trend["direction"] == "increasing" and trend["strength"] in ["moderate", "strong"]:
     print("⚠️ Performance degradation trend detected!")
     print(f"Predicted next value: {trend['predicted_next']:.2f}s")
 ```
@@ -331,10 +328,10 @@ The enhanced statistical analysis is fully backward compatible:
 
 ```python
 # Basic usage still works
-has_regression, details = detector.detect_regression('v1.0', 'v1.1')
+has_regression, details = detector.detect_regression("v1.0", "v1.1")
 
 # Enhanced features available when configured
-if detector.statistical_config['enable_trend_analysis']:
+if detector.statistical_config["enable_trend_analysis"]:
     # Statistical analysis automatically included
     pass
 ```
@@ -346,8 +343,9 @@ Statistical analysis results are published via the event system:
 ```python
 # Listen for enhanced regression events
 def handle_statistical_regression(event_data):
-    if event_data.get('statistical_significance') == 'significant':
+    if event_data.get("statistical_significance") == "significant":
         trigger_detailed_investigation()
+
 
 subscribe(EventType.REGRESSION_DETECTED, handle_statistical_regression)
 ```
@@ -381,23 +379,23 @@ subscribe(EventType.REGRESSION_DETECTED, handle_statistical_regression)
 
 #### Insufficient Historical Data
 ```python
-stats = detector.analyze_metric_statistics('metric', values)
-if 'error' in stats:
+stats = detector.analyze_metric_statistics("metric", values)
+if "error" in stats:
     print("Need more historical data for statistical analysis")
 ```
 
 #### No Trend Detected
 ```python
-trend = stats['trend_analysis']
-if trend.get('strength') == 'negligible':
+trend = stats["trend_analysis"]
+if trend.get("strength") == "negligible":
     print("No significant trend - data may be stable or noisy")
 ```
 
 #### False Positives in Anomaly Detection
 ```python
 # Adjust sensitivity
-config['anomaly_detection']['sensitivity'] = 'low'  # Reduce false positives
-config['statistical_analysis']['outlier_threshold'] = 2.5  # More conservative
+config["anomaly_detection"]["sensitivity"] = "low"  # Reduce false positives
+config["statistical_analysis"]["outlier_threshold"] = 2.5  # More conservative
 ```
 
 ## API Reference

--- a/docs/user/manual.md
+++ b/docs/user/manual.md
@@ -133,11 +133,7 @@ evoseal = EVOSEAL()
 task = "Create a Python function that implements quicksort"
 
 # Run evolution
-result = evoseal.evolve(
-    task=task,
-    max_iterations=50,
-    population_size=10
-)
+result = evoseal.evolve(task=task, max_iterations=50, population_size=10)
 
 # Access results
 print(f"Best solution: {result.best_solution}")
@@ -160,6 +156,7 @@ def custom_fitness(solution):
     # Add your custom evaluation logic here
 
     return score
+
 
 # Initialize with custom fitness
 custom_evoseal = EVOSEAL(fitness_function=custom_fitness)

--- a/evoseal/core/events/README.md
+++ b/evoseal/core/events/README.md
@@ -206,17 +206,17 @@ The basic EventBus provides core event publishing and subscription functionality
 ```python
 from evoseal.core.events import event_bus, EventType, Event
 
+
 # Subscribe to events
 @event_bus.subscribe(EventType.WORKFLOW_STARTED)
 async def on_workflow_started(event: Event):
     print(f"Workflow started: {event.data}")
 
+
 # Publish events
 await event_bus.publish(
     Event(
-        event_type=EventType.WORKFLOW_STARTED,
-        source="my_component",
-        data={"workflow_id": "wf-001"}
+        event_type=EventType.WORKFLOW_STARTED, source="my_component", data={"workflow_id": "wf-001"}
     )
 )
 ```
@@ -235,10 +235,7 @@ enhanced_event_bus.enable_event_logging(max_history=1000)
 metrics = enhanced_event_bus.get_event_metrics()
 
 # Get event history
-history = enhanced_event_bus.get_event_history(
-    event_type=EventType.ERROR_OCCURRED,
-    limit=50
-)
+history = enhanced_event_bus.get_event_history(event_type=EventType.ERROR_OCCURRED, limit=50)
 
 # Batch publish events
 events = [
@@ -256,9 +253,11 @@ await enhanced_event_bus.publish_batch(events)
 ```python
 from evoseal.core.events import subscribe, EventType
 
+
 @subscribe(EventType.ERROR_OCCURRED)
 async def handle_error(event: Event):
     print(f"Error: {event.data}")
+
 
 @subscribe(priority=100)  # High priority
 async def high_priority_handler(event: Event):
@@ -270,8 +269,10 @@ async def high_priority_handler(event: Event):
 ```python
 from evoseal.core.events import event_bus
 
+
 async def my_handler(event: Event):
     print(f"Received: {event.event_type}")
+
 
 event_bus.subscribe(EventType.WORKFLOW_STARTED, my_handler)
 ```
@@ -284,8 +285,9 @@ from evoseal.core.events import subscribe, create_event_filter
 error_filter = create_event_filter(
     event_types=[EventType.ERROR_OCCURRED],
     sources=["component1", "component2"],
-    severity_levels=["error", "critical"]
+    severity_levels=["error", "critical"],
 )
+
 
 @subscribe(filter_fn=error_filter)
 async def handle_filtered_errors(event: Event):
@@ -302,7 +304,7 @@ await publish(
     EventType.WORKFLOW_STARTED,
     source="my_component",
     workflow_id="wf-001",
-    timestamp="2024-01-01T10:00:00Z"
+    timestamp="2024-01-01T10:00:00Z",
 )
 ```
 
@@ -312,19 +314,13 @@ from evoseal.core.events import create_error_event, create_progress_event
 
 # Create and publish error event
 error_event = create_error_event(
-    error=ValueError("Something went wrong"),
-    source="my_component",
-    severity="error"
+    error=ValueError("Something went wrong"), source="my_component", severity="error"
 )
 await event_bus.publish(error_event)
 
 # Create and publish progress event
 progress_event = create_progress_event(
-    current=50,
-    total=100,
-    stage="processing",
-    source="my_component",
-    message="Half way done"
+    current=50, total=100, stage="processing", source="my_component", message="Half way done"
 )
 await event_bus.publish(progress_event)
 ```
@@ -335,18 +331,12 @@ from evoseal.core.events import publish_component_lifecycle_event, publish_pipel
 
 # Publish component lifecycle event
 await publish_component_lifecycle_event(
-    component_type="DGM",
-    component_id="dgm-001",
-    lifecycle_event="started",
-    source="orchestrator"
+    component_type="DGM", component_id="dgm-001", lifecycle_event="started", source="orchestrator"
 )
 
 # Publish pipeline stage event
 await publish_pipeline_stage_event(
-    stage="analyzing",
-    status="completed",
-    source="pipeline",
-    progress={"current": 1, "total": 5}
+    stage="analyzing", status="completed", source="pipeline", progress={"current": 1, "total": 5}
 )
 ```
 
@@ -360,23 +350,25 @@ from evoseal.core.events import create_event_filter, subscribe
 # Filter by event types and sources
 component_filter = create_event_filter(
     event_types=[EventType.COMPONENT_STARTED, EventType.COMPONENT_STOPPED],
-    sources=["orchestrator", "pipeline"]
+    sources=["orchestrator", "pipeline"],
 )
 
 # Filter by severity levels
 error_filter = create_event_filter(
     event_types=[EventType.ERROR_OCCURRED, EventType.WARNING_ISSUED],
-    severity_levels=["error", "critical"]
+    severity_levels=["error", "critical"],
 )
+
 
 # Custom filter function
 def custom_filter(event: Event) -> bool:
     return "important" in event.data.get("tags", [])
 
+
 combined_filter = create_event_filter(
-    event_types=[EventType.INFO_MESSAGE],
-    custom_filter=custom_filter
+    event_types=[EventType.INFO_MESSAGE], custom_filter=custom_filter
 )
+
 
 @subscribe(filter_fn=combined_filter)
 async def handle_important_info(event: Event):
@@ -405,7 +397,7 @@ error_metrics = enhanced_event_bus.get_event_metrics(EventType.ERROR_OCCURRED)
         "first_seen": 1640995200.0,
         "last_seen": 1640995800.0,
         "sources": ["component1", "component2", "pipeline"],
-        "avg_processing_time": 0.05
+        "avg_processing_time": 0.05,
     }
 }
 ```
@@ -419,10 +411,7 @@ Track and query recent events:
 recent_events = enhanced_event_bus.get_event_history(limit=100)
 
 # Get recent error events
-error_history = enhanced_event_bus.get_event_history(
-    event_type=EventType.ERROR_OCCURRED,
-    limit=50
-)
+error_history = enhanced_event_bus.get_event_history(event_type=EventType.ERROR_OCCURRED, limit=50)
 
 # Clear history
 enhanced_event_bus.clear_event_history()
@@ -449,13 +438,14 @@ Components can publish events using the helper functions:
 ```python
 from evoseal.core.events import publish_component_lifecycle_event
 
+
 class MyComponent:
     async def start(self):
         await publish_component_lifecycle_event(
             component_type="MyComponent",
             component_id=self.component_id,
             lifecycle_event="started",
-            source="my_component"
+            source="my_component",
         )
 ```
 
@@ -504,6 +494,7 @@ class MyComponent:
 import asyncio
 from evoseal.core.events import subscribe, EventType, enhanced_event_bus
 
+
 class PipelineMonitor:
     def __init__(self):
         self.setup_event_handlers()
@@ -516,12 +507,12 @@ class PipelineMonitor:
 
         @subscribe(EventType.ITERATION_COMPLETED)
         async def on_iteration_completed(event):
-            iteration = event.data.get('iteration', '?')
+            iteration = event.data.get("iteration", "?")
             print(f"✅ Iteration {iteration} completed")
 
         @subscribe(EventType.ERROR_OCCURRED, priority=200)
         async def on_error(event):
-            severity = event.data.get('severity', 'unknown')
+            severity = event.data.get("severity", "unknown")
             print(f"❌ Error ({severity}): {event.data.get('error_message', 'Unknown error')}")
 
         @subscribe()  # Subscribe to all events
@@ -536,8 +527,9 @@ class PipelineMonitor:
         return {
             "metrics": metrics,
             "recent_events": len(history),
-            "error_count": metrics.get("error_occurred", {}).get("count", 0)
+            "error_count": metrics.get("error_occurred", {}).get("count", 0),
         }
+
 
 # Usage
 monitor = PipelineMonitor()
@@ -561,10 +553,11 @@ await event_bus.publish(
         data={
             "analysis_id": "analysis-001",
             "results": {"complexity": 8.5, "issues": 3},
-            "duration": 45.2
-        }
+            "duration": 45.2,
+        },
     )
 )
+
 
 # Subscribe to custom events
 @subscribe(CUSTOM_ANALYSIS_COMPLETED)

--- a/evoseal/integration/README.md
+++ b/evoseal/integration/README.md
@@ -49,7 +49,7 @@ The DGM adapter provides integration with the Dynamic Generation Management syst
 dgm_config = {
     "output_dir": "/path/to/dgm/output",
     "prevrun_dir": "/path/to/previous/runs",  # Optional
-    "polyglot": False
+    "polyglot": False,
 }
 ```
 
@@ -73,7 +73,7 @@ openevolve_config = {
     "openevolve_path": "/path/to/openevolve",  # Auto-detected if not provided
     "working_dir": "/path/to/working/directory",
     "python_executable": "python3",
-    "environment": {"ENV_VAR": "value"}  # Optional environment variables
+    "environment": {"ENV_VAR": "value"},  # Optional environment variables
 }
 ```
 
@@ -98,7 +98,7 @@ seal_config = {
     "provider_config": {},
     "rate_limit_per_sec": 1.0,
     "max_retries": 3,
-    "retry_delay": 1.0
+    "retry_delay": 1.0,
 }
 ```
 
@@ -137,8 +137,7 @@ from evoseal.core.evolution_pipeline import EvolutionPipeline, EvolutionConfig
 
 # Create configuration with component configs
 config = EvolutionConfig(
-    dgm_config={"output_dir": "/tmp/dgm"},
-    seal_config={"provider_type": "default"}
+    dgm_config={"output_dir": "/tmp/dgm"}, seal_config={"provider_type": "default"}
 )
 
 # Create and initialize pipeline
@@ -150,7 +149,7 @@ await pipeline.start_components()
 workflow_config = {
     "workflow_id": "example",
     "dgm_config": {"selfimprove_size": 2},
-    "seal_config": {"code": "def example(): pass"}
+    "seal_config": {"code": "def example(): pass"},
 }
 result = await pipeline.execute_evolution_workflow(workflow_config)
 
@@ -242,6 +241,7 @@ To create a custom component adapter:
 ```python
 from evoseal.integration.base_adapter import BaseComponentAdapter, ComponentType
 
+
 class CustomAdapter(BaseComponentAdapter):
     async def _initialize_impl(self) -> bool:
         # Initialize your component
@@ -278,11 +278,12 @@ class CustomSEALProvider:
         # Your custom parsing logic
         pass
 
+
 # Use with SEAL (Self-Adapting Language Models) adapter
 seal_config = {
     "provider_type": "custom",
     "provider_class": CustomSEALProvider,
-    "provider_config": {"api_key": "your_key"}  # pragma: allowlist secret
+    "provider_config": {"api_key": "your_key"},  # pragma: allowlist secret
 }
 ```
 
@@ -321,7 +322,8 @@ Enable debug logging to get detailed information:
 
 ```python
 import logging
-logging.getLogger('evoseal.integration').setLevel(logging.DEBUG)
+
+logging.getLogger("evoseal.integration").setLevel(logging.DEBUG)
 ```
 
 ## Future Enhancements

--- a/evoseal/integration/seal/data_loaders/README.md
+++ b/evoseal/integration/seal/data_loaders/README.md
@@ -23,11 +23,13 @@ from pathlib import Path
 from pydantic import BaseModel
 from evoseal.integration.seal.data_loaders import load_data
 
+
 # Define your data model
 class ExampleModel(BaseModel):
     id: str
     name: str
     value: int
+
 
 # Load data from a file
 data = load_data("examples/data.json", ExampleModel)
@@ -42,18 +44,14 @@ data = load_data("examples/data.yaml", ExampleModel, format="yaml")
 from evoseal.integration.seal.data_loaders import load_batch
 
 # Load multiple files in parallel
-data = load_batch(
-    ["data/file1.json", "data/file2.json"],
-    ExampleModel,
-    max_workers=4
-)
+data = load_batch(["data/file1.json", "data/file2.json"], ExampleModel, max_workers=4)
 
 # Or load all files in a directory
 data = load_batch(
     "data/",
     ExampleModel,
     pattern="*.json",  # Only load JSON files
-    recursive=True     # Search subdirectories
+    recursive=True,  # Search subdirectories
 )
 ```
 
@@ -64,6 +62,7 @@ from evoseal.integration.seal.data_loaders import cached, default_cache
 
 # Clear the cache
 default_cache.clear()
+
 
 # Use the cache decorator
 @cached(ttl=3600)  # Cache for 1 hour

--- a/evoseal/integration/seal/few_shot/README.md
+++ b/evoseal/integration/seal/few_shot/README.md
@@ -29,15 +29,17 @@ learner = FewShotLearner(
     base_model_name="meta-llama/Llama-3.2-1B-Instruct",
     lora_rank=16,
     lora_alpha=32,
-    lora_dropout=0.05
+    lora_dropout=0.05,
 )
 
 # Add examples
-learner.add_example(FewShotExample(
-    input_data="What is the capital of France?",
-    output_data="The capital of France is Paris.",
-    metadata={"difficulty": "easy"}
-))
+learner.add_example(
+    FewShotExample(
+        input_data="What is the capital of France?",
+        output_data="The capital of France is Paris.",
+        metadata={"difficulty": "easy"},
+    )
+)
 
 # Generate a response
 response = learner.generate("What is the capital of Italy?")
@@ -49,10 +51,7 @@ print(response)
 ```python
 # Fine-tune the model on your examples
 learner.fine_tune(
-    output_dir="./few_shot_model",
-    num_epochs=3,
-    per_device_train_batch_size=4,
-    learning_rate=2e-5
+    output_dir="./few_shot_model", num_epochs=3, per_device_train_batch_size=4, learning_rate=2e-5
 )
 
 # Save and load examples
@@ -121,11 +120,9 @@ def custom_formatter(query: str, examples: List[FewShotExample]) -> str:
     prompt += f"Q: {query}\nA:"
     return prompt
 
+
 # Use custom formatter
-response = learner.generate(
-    "What is the capital of Spain?",
-    format_func=custom_formatter
-)
+response = learner.generate("What is the capital of Spain?", format_func=custom_formatter)
 ```
 
 ### Custom Similarity Metrics
@@ -135,6 +132,7 @@ def custom_similarity(query: str, example: FewShotExample) -> float:
     """Custom similarity function."""
     # Implement your similarity logic here
     return 0.5  # Dummy value
+
 
 # Use custom similarity function
 learner.get_relevant_examples("query", similarity_func=custom_similarity)

--- a/evoseal/integration/seal/self_editor/README.md
+++ b/evoseal/integration/seal/self_editor/README.md
@@ -42,8 +42,9 @@ from evoseal.integration.seal.self_editor import (
     EditStrategy,
     EditSuggestion,
     EditOperation,
-    EditCriteria
+    EditCriteria,
 )
+
 
 class GrammarCheckStrategy(EditStrategy):
     """A simple grammar checking strategy."""
@@ -54,19 +55,22 @@ class GrammarCheckStrategy(EditStrategy):
 
         # Example: Check for common errors
         if "design to" in content and "designed to" not in content:
-            suggestions.append(EditSuggestion(
-                operation=EditOperation.REPLACE,
-                criteria=[EditCriteria.GRAMMAR],
-                original_text="design to",
-                suggested_text="designed to",
-                confidence=0.9,
-                explanation="Correct verb form should be 'designed to' in this context"
-            ))
+            suggestions.append(
+                EditSuggestion(
+                    operation=EditOperation.REPLACE,
+                    criteria=[EditCriteria.GRAMMAR],
+                    original_text="design to",
+                    suggested_text="designed to",
+                    confidence=0.9,
+                    explanation="Correct verb form should be 'designed to' in this context",
+                )
+            )
 
         return suggestions
 
     def apply_edit(self, content: str, suggestion: EditSuggestion) -> str:
         return content.replace(suggestion.original_text, suggestion.suggested_text)
+
 
 # Use the custom strategy
 editor = SelfEditor(strategy=GrammarCheckStrategy())

--- a/evoseal/utils/logging/README.md
+++ b/evoseal/utils/logging/README.md
@@ -54,6 +54,7 @@ except Exception as e:
 ```python
 from evoseal.utils.logging import LoggingMixin
 
+
 class MyService(LoggingMixin):
     def __init__(self):
         super().__init__()
@@ -71,6 +72,7 @@ from evoseal.utils.logging import with_request_id, setup_logging
 
 logger = setup_logging()
 
+
 @with_request_id(logger)
 def process_request(request_data):
     logger.info("Processing request", extra={"user_id": request_data.user_id})
@@ -83,10 +85,12 @@ def process_request(request_data):
 ```python
 from evoseal.utils.logging import log_execution_time
 
+
 @log_execution_time(logger)
 def expensive_operation():
     # Time-consuming operation
     import time
+
     time.sleep(1)
     return "result"
 ```

--- a/evoseal/utils/version_control/cmd_git.py
+++ b/evoseal/utils/version_control/cmd_git.py
@@ -974,7 +974,10 @@ class CmdGit(GitInterface):
                 if force:
                     cmd.append("-f")
                 if sign or sign_key:
-                    cmd.append("-s" if not sign_key else f"-u {sign_key}")
+                    if sign_key:
+                        cmd.extend(["-u", sign_key])
+                    else:
+                        cmd.append("-s")
                 cmd.append(name)
                 if commit:
                     cmd.append(commit)


### PR DESCRIPTION
## What

`cmd.append(f"-u {sign_key}")` in `cmd_git.py:977` put `-u mykey` as a single argv element. Since `subprocess.run` uses a list (not shell), git received one malformed token instead of the expected flag + value pair.

## How

Changed from:
```python
cmd.append("-s" if not sign_key else f"-u {sign_key}")
```
To:
```python
if sign_key:
    cmd.extend(["-u", sign_key])
else:
    cmd.append("-s")
```

## Verification

- `ruff format --check evoseal/utils/version_control/cmd_git.py` ✅
- `ruff check evoseal/ tests/` ✅
- `pytest tests/unit/ -q` — 472 passed, 5 skipped ✅

Addresses TODO.md item: **`cmd_git.py:977` `tag()` builds a malformed argv token**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed signed Git tag creation to correctly use the provided signing key (vs the default signing option).

* **Documentation**
  * Updated examples and API reference formatting across the project (quoting, line wrapping, and spacing) in guides, architecture docs, safety materials, integration docs, and the user manual.

* **Chores**
  * Refreshed progress tracking in the project task list to mark the Git tagging item complete and adjust the “Done” totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->