### PR TITLE
fix: remove spurious quotes from credential.helper config

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -253,7 +253,7 @@
 ### Low-Priority / Hygiene Issues Found in Whole-Repo Code Review (2026-07-22)
 
 - [x] **`cmd_git.py:977` `tag()` builds a malformed argv token** — `cmd.append("-s" if not sign_key else f"-u {sign_key}")` appends `"-u <key>"` as one argv element instead of `["-u", sign_key]`; since commands run via `subprocess.run(list, shell=False)`, git receives one malformed token and signed-tag-with-explicit-key fails
-- [ ] **`git_interface.py` credential-helper config is broken** — sets `credential.helper` to the literal string `'cache --timeout=300'` including the quotes (no shell involved, so they're taken literally), via two non-`--add` `--local` sets where the second silently overwrites the first with a bogus value — HTTPS credential caching silently doesn't work
+- [x] **`git_interface.py` credential-helper config is broken** _(done 2026-07-24)_ — sets `credential.helper` to the literal string `'cache --timeout=300'` including the quotes (no shell involved, so they're taken literally), via two non-`--add` `--local` sets where the second silently overwrites the first with a bogus value — HTTPS credential caching silently doesn't work. Fixed to a single `config --local credential.helper "cache --timeout=300"` call with no spurious quotes
 - [ ] **Stray `evoseal/utils/validator.py.bak`** — a 1132-line backup committed to the repo tree (not gitignored), diverged from `validator.py`; risk of editing the wrong file
 - [ ] **`evoseal/utils/testing/environment.py:180`** — `suffix: str = None` type-annotation mismatch (should be `Optional[str]`)
 - [ ] **`providers/ollama_provider.py:98-136`** — `submit_prompt` has no retry/backoff on transient network failures despite being the sole retry/timeout surface for local model calls
@@ -304,7 +304,7 @@
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 11   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
 | 🟡 P2    | 29    | 6    | Co-evolution loop gaps (7 items, 6 done) + existing P2 + 12 medium bugs from 2026-07-22 review |
-| 🟢 P3    | 24    | 7    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
+| 🟢 P3    | 24    | 8    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
 | **Total** | **88** | **35** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.

--- a/evoseal/utils/version_control/git_interface.py
+++ b/evoseal/utils/version_control/git_interface.py
@@ -318,8 +318,7 @@ class GitInterface(ABC):
             return
 
         # Configure Git to cache credentials in memory for a short time
-        self._run_git_command(["config", "--local", "credential.helper", "cache"])
-        self._run_git_command(["config", "--local", "credential.helper", "'cache --timeout=300'"])
+        self._run_git_command(["config", "--local", "credential.helper", "cache --timeout=300"])
 
     def _get_auth_env(self) -> dict[str, str]:
         """Get the environment variables for authentication."""


### PR DESCRIPTION
## What

Replace the two broken `git config --local credential.helper` calls in `_configure_credential_helper` with a single correct one.

## Why

`git_interface.py:321-322` set `credential.helper` to the literal string `'cache --timeout=300'` — including the single quotes. Since commands run through `subprocess.run(list, shell=False)`, there is no shell to strip quotes; git received the value with quotes embedded and would look for a credential helper literally named `'cache` (with opening quote) rather than `cache`.

Additionally, line 321 set `credential.helper` to `"cache"` which was immediately overwritten by line 322 — a wasted write.

## How

Replaced both lines with one:
```python
self._run_git_command(["config", "--local", "credential.helper", "cache --timeout=300"])
```

## Verification

- `ruff format --check .` ✅ (390 files clean)
- `ruff check evoseal/ tests/` ✅
- `pytest tests/` — 710 passed, 2 e2e skipped (expected — e2e needs mock server), 9 skipped ✅

Addresses TODO.md item: **`git_interface.py` credential-helper config is broken**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git credential caching configuration to apply the intended five-minute timeout consistently.
  * Prevented incorrect credential-helper values from being stored in local Git settings.

* **Documentation**
  * Updated project tracking to reflect the completed maintenance item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->