### PR TITLE
fix: catch yaml.YAMLError in SystemConfig.from_yaml

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -218,7 +218,7 @@
 - [ ] **`continuous_evolution_service.py:107-115` registers process-wide signal handlers from `__init__`** — `signal.signal()` only works on the main thread (raises `ValueError` if constructed off-thread), and the handler's `asyncio.create_task(self.shutdown())` requires a running event loop in the current thread at signal-time; also clobbers whatever signal handlers an embedding application had installed, since this fires on mere construction, not `start()`
 - [x] **`models/experiment.py:256-260` references an undefined name `FieldValidationInfo`** — never imported anywhere in the module (only `field_validator`/`model_validator` are imported from pydantic); only survives today because `from __future__ import annotations` defers evaluation. Breaks under `typing.get_type_hints()`, strict mypy/pyright, or Sphinx autodoc. Correct type is `pydantic.ValidationInfo`
 - [x] **`models/system_config.py:33-39` `from_yaml` doesn't validate the loaded YAML is a dict** _(done 2026-07-24)_ — an empty file yields `None`, a scalar/list document yields a non-dict; `self.config` is set as-is and the first `get()`/`validate()` call raises an opaque `TypeError` instead of a clear config error
-- [ ] **`models/system_config.py` `from_yaml` doesn't catch `yaml.YAMLError` on malformed YAML syntax** — `yaml.safe_load()` raises `yaml.YAMLError` on invalid YAML (e.g. bad indentation, unclosed braces); the raw exception propagates without context about which file failed to parse
+- [x] **`models/system_config.py` `from_yaml` doesn't catch `yaml.YAMLError` on malformed YAML syntax** — `yaml.safe_load()` raises `yaml.YAMLError` on invalid YAML (e.g. bad indentation, unclosed braces); the raw exception propagates without context about which file failed to parse
 - [ ] **`cmd_git.py:1754` `_find_referenced_by` passes a nonexistent `ref` kwarg** — calls `self._run_git_command(cmd, ref=ref)`, but `GitInterface._run_git_command` has no `ref` parameter; raises `TypeError` any time `find_file_references()` is called with an explicit ref
 
 ### Evolution Archive & Rollout _(inspired by OpenClaw patterns)_
@@ -306,9 +306,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 11   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
-| 🟡 P2    | 30    | 12   | Co-evolution loop gaps (7 items, 7 done) + existing P2 + 12 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap logged) |
+| 🟡 P2    | 30    | 13   | Co-evolution loop gaps (7 items, 7 done) + existing P2 + 12 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap logged) |
 | 🟢 P3    | 24    | 8    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
-| **Total** | **89** | **41** | |
+| **Total** | **89** | **42** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/evoseal/models/system_config.py
+++ b/evoseal/models/system_config.py
@@ -35,7 +35,12 @@ class SystemConfig:
         if not os.path.exists(yaml_path):
             raise FileNotFoundError(f"YAML config file not found: {yaml_path}")
         with open(yaml_path) as f:
-            config_dict = yaml.safe_load(f)
+            try:
+                config_dict = yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                raise ValueError(
+                    f"YAML config file {yaml_path} contains invalid YAML syntax: {e}"
+                ) from e
         if not isinstance(config_dict, dict):
             raise ValueError(
                 f"YAML config file {yaml_path} did not produce a mapping "

--- a/tests/unit/models/test_system_config.py
+++ b/tests/unit/models/test_system_config.py
@@ -76,3 +76,15 @@ def test_from_yaml_list_raises():
             SystemConfig.from_yaml(yaml_path)
     finally:
         os.remove(yaml_path)
+
+
+def test_from_yaml_malformed_syntax_raises():
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        # Invalid YAML: bad indentation triggers yaml.YAMLError
+        f.write("key:\n  - item\n bad_indent")
+        yaml_path = f.name
+    try:
+        with pytest.raises(ValueError, match="invalid YAML syntax"):
+            SystemConfig.from_yaml(yaml_path)
+    finally:
+        os.remove(yaml_path)


### PR DESCRIPTION
## What

Wrap `yaml.safe_load()` in `SystemConfig.from_yaml()` with a `try/except yaml.YAMLError` to catch malformed YAML syntax (bad indentation, unclosed braces, etc.) and raise a clear `ValueError` with the file path and error detail, instead of letting the raw `yaml.YAMLError` propagate.

Adds regression test `test_from_yaml_malformed_syntax_raises`.

## Why

Addresses TODO.md item: *"models/system_config.py from_yaml doesn't catch yaml.YAMLError on malformed YAML syntax"*

Previously, a malformed YAML file would raise a bare `yaml.YAMLError` with no context about which file failed. Now it raises `ValueError` with a message matching the pattern used by the existing non-dict validation, e.g.:

```
ValueError: YAML config file /path/to/file.yaml contains invalid YAML syntax: ...
```

## Verification

- `ruff format --check .` — ✅
- `ruff check evoseal/ tests/` — ✅
- `pytest tests/unit/models/test_system_config.py -q` — ✅ 7 passed
- Full test suite — ✅ 604 passed

Closes TODO.md P2 item: `models/system_config.py from_yaml doesn't catch yaml.YAMLError on malformed YAML syntax`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed YAML configuration files by reporting a clear validation error, including the file path and parsing details.

* **Tests**
  * Added coverage to verify invalid YAML syntax is rejected correctly.

* **Documentation**
  * Updated task tracking to reflect completion of malformed-YAML handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->