### PR TITLE
fix: pass git ref as command arg in _find_referenced_by

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -219,7 +219,7 @@
 - [x] **`models/experiment.py:256-260` references an undefined name `FieldValidationInfo`** — never imported anywhere in the module (only `field_validator`/`model_validator` are imported from pydantic); only survives today because `from __future__ import annotations` defers evaluation. Breaks under `typing.get_type_hints()`, strict mypy/pyright, or Sphinx autodoc. Correct type is `pydantic.ValidationInfo`
 - [x] **`models/system_config.py:33-39` `from_yaml` doesn't validate the loaded YAML is a dict** _(done 2026-07-24)_ — an empty file yields `None`, a scalar/list document yields a non-dict; `self.config` is set as-is and the first `get()`/`validate()` call raises an opaque `TypeError` instead of a clear config error
 - [x] **`models/system_config.py` `from_yaml` doesn't catch `yaml.YAMLError` on malformed YAML syntax** — `yaml.safe_load()` raises `yaml.YAMLError` on invalid YAML (e.g. bad indentation, unclosed braces); the raw exception propagates without context about which file failed to parse
-- [ ] **`cmd_git.py:1754` `_find_referenced_by` passes a nonexistent `ref` kwarg** — calls `self._run_git_command(cmd, ref=ref)`, but `GitInterface._run_git_command` has no `ref` parameter; raises `TypeError` any time `find_file_references()` is called with an explicit ref
+- [x] **`cmd_git.py:1754` `_find_referenced_by` passes a nonexistent `ref` kwarg** — calls `self._run_git_command(cmd, ref=ref)`, but `GitInterface._run_git_command` has no `ref` parameter; raises `TypeError` any time `find_file_references()` is called with an explicit ref
 
 ### Evolution Archive & Rollout _(inspired by OpenClaw patterns)_
 
@@ -306,9 +306,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 11   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
-| 🟡 P2    | 30    | 13   | Co-evolution loop gaps (7 items, 7 done) + existing P2 + 12 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap logged) |
+| 🟡 P2    | 30    | 14   | Co-evolution loop gaps (7 items, 7 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap logged) |
 | 🟢 P3    | 24    | 8    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
-| **Total** | **89** | **42** | |
+| **Total** | **89** | **43** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/evoseal/utils/version_control/cmd_git.py
+++ b/evoseal/utils/version_control/cmd_git.py
@@ -1754,7 +1754,16 @@ class CmdGit(GitInterface):
                 patterns = " ".join(f"*.{ft.lstrip('.')}" for ft in file_types)
                 cmd.extend(["--"] + patterns.split())
 
-            success, stdout, _ = self._run_git_command(cmd, ref=ref)
+            # If a ref is specified, insert it so `git grep` searches that
+            # revision.  It must go before any "--" pathspec separator.
+            if ref:
+                try:
+                    dd = cmd.index("--")
+                    cmd.insert(dd, ref)
+                except ValueError:
+                    cmd.append(ref)
+
+            success, stdout, _ = self._run_git_command(cmd)
 
             if not success or not stdout.strip():
                 return []


### PR DESCRIPTION
## What

`_find_referenced_by` in `evoseal/utils/version_control/cmd_git.py` passed `ref=ref` as a keyword argument to `self._run_git_command()`, but `GitInterface._run_git_command` has no `ref` parameter — every call with an explicit ref raised `TypeError`.

## Fix

Instead of passing `ref` as a kwarg to `_run_git_command`, insert it into the git grep command args list. `git grep [opts] [commit] [--] [pathspec]` expects the revision before any `--` pathspec separator, so the fix uses `cmd.index("--")` to find the right insertion point (falls back to appending when no `--` is present).

## Addresses

TODO.md item: "`cmd_git.py:1754` `_find_referenced_by` passes a nonexistent `ref` kwarg" under 🟡 P2 — Medium-Priority Bugs.

## Verification

- `ruff format --check .` ✅ (392 files formatted)
- `ruff check evoseal/ tests/` ✅ (all checks passed)
- `pytest tests/version_control/ tests/unit/storage/test_git_storage.py -q` → 41 passed ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed reference-based searches in Git history to correctly apply the selected revision.
  - Resolved errors that could occur when determining where changes were referenced.

- **Documentation**
  - Updated project tracking to reflect completion of this work item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->