### PR TITLE
fix: correct import path in agentic_system_example.py

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -264,7 +264,7 @@
 - [ ] **`model_fine_tuner.py:122-137`** — `_check_gpu_availability()` is defined but never called; despite the module docstring claiming "Requires a CUDA GPU," `initialize_model()` silently proceeds on CPU instead of failing fast
 - [ ] **`model_fine_tuner.py:220,240`** — `example['instruction']`/`example['output']` direct dict access with no `.get()`; a malformed training example raises `KeyError` surfaced only as a generic error string instead of a clear validation message
 - [ ] **`models/code_archive.py:127-149`** — `__init__` manually re-implements every default already provided by `Field(default_factory=...)`, a drift hazard (two sources of truth for the same defaults)
-- [ ] **`evoseal/agents/agentic_system_example.py:7`** — `from evoseal.agentic_system import ...` is the wrong module path (actual: `evoseal.agents.agentic_system`); the example fails immediately with `ModuleNotFoundError`
+- [x] **`evoseal/agents/agentic_system_example.py:7`** — `from evoseal.agentic_system import ...` is the wrong module path (actual: `evoseal.agents.agentic_system`); the example fails immediately with `ModuleNotFoundError`
 
 ### Documentation Polish
 
@@ -307,8 +307,8 @@
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 11   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
 | 🟡 P2    | 30    | 15   | Co-evolution loop gaps (7 items, 7 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap logged) |
-| 🟢 P3    | 24    | 9    | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
-| **Total** | **89** | **44** | |
+| 🟢 P3    | 24    | 10   | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
+| **Total** | **89** | **45** |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/evoseal/agents/agentic_system_example.py
+++ b/evoseal/agents/agentic_system_example.py
@@ -4,7 +4,7 @@ Example usage of AgenticSystem with a simple agent.
 
 from typing import Any
 
-from evoseal.agentic_system import Agent, AgenticSystem
+from evoseal.agents.agentic_system import Agent, AgenticSystem
 
 
 class EchoAgent(Agent):


### PR DESCRIPTION
## What

`evoseal/agents/agentic_system_example.py` imported from `evoseal.agentic_system`, which does not exist. The correct module is `evoseal.agents.agentic_system`. This caused an immediate `ModuleNotFoundError` when running the example.

## Why

The import path was wrong — `evoseal.agentic_system` is not a valid module. The actual `AgenticSystem` class lives at `evoseal.agents.agentic_system`.

## Changes

- Fixed the import in `agentic_system_example.py` from `evoseal.agentic_system` → `evoseal.agents.agentic_system`
- Ticked the corresponding `TODO.md` checkbox (P3 hygiene item)

## Verification

- `ruff format --check .` ✅
- `ruff check evoseal/ tests/` ✅
- `pytest tests/ --ignore=tests/e2e` → 604 passed, 23 deselected ✅
- `python -c "import evoseal.agents.agentic_system_example"` → Import OK ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an import issue in the agentic system example that could cause a `ModuleNotFoundError`.
  * The example can now be run with its existing setup and workflow.

* **Documentation**
  * Updated project tracking to mark the completed maintenance item as done.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->