### PR TITLE
fix: use atomic write for version registry to prevent data loss on crash

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -308,7 +308,7 @@
 | 🟠 P1    | 24    | 11   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
 | 🟡 P2    | 30    | 16   | Co-evolution loop gaps (7 items, 7 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap logged) |
 | 🟢 P3    | 24    | 10   | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
-| **Total** | **89** | **45** |
+| **Total** | **89** | **48** |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -209,7 +209,7 @@
 ### Medium-Priority Bugs Found in Whole-Repo Code Review (2026-07-22)
 
 - [x] **`bidirectional_manager.py` state fields are never mutated** _(done 2026-07-23)_ — fixed by `run_loop_cycle()` in item #6 above; `stats`, `evolution_history`, `is_running`, and `last_check_time` are now all mutated each cycle.
-- [ ] **`version_manager.py` registry file has no atomic write** — `_save_registry()` (lines 70-77, PR #72 branch) writes directly via `open(...,"w")` + `json.dump`; a crash/kill mid-write leaves a truncated file, and `_load_registry()` silently resets to an empty registry on parse failure, losing all version history
+- [x] **`version_manager.py` registry file has no atomic write** — `_save_registry()` (lines 70-77, PR #72 branch) writes directly via `open(...,"w")` + `json.dump`; a crash/kill mid-write leaves a truncated file, and `_load_registry()` silently resets to an empty registry on parse failure, losing all version history
 - [ ] **`version_manager.py` has no locking around concurrent registry mutation** — overlapping `register_version`/`deploy_version` calls can interleave writes to `self.registry["versions"]`, risking lost updates or an inconsistent `current_version`
 - [ ] **`model_fine_tuner.py:160-178` uses `trust_remote_code=True`** on both `AutoTokenizer`/`AutoModelForCausalLM.from_pretrained`, combined with a fallback (`_resolve_hf_base_model()`, lines 107-120) that uses `model_name` verbatim as an HF repo id for unknown families — a bad config value or env var (`EVOSEAL_CODER_MODEL`) can execute arbitrary remote code locally. `# nosec B615` suppresses the linter, not the risk
 - [ ] **`provider_manager.py` treats unhealthy providers as healthy when called from a running event loop** — `get_best_available_provider()` (lines 100-111) and `list_providers()` (lines 196-201) create a health-check task via `loop.create_task(...)` but never await/consume it, then unconditionally set `is_healthy = True`, discarding the real result; the orphaned task can also produce unretrieved-exception warnings
@@ -306,7 +306,7 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 11   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review |
-| 🟡 P2    | 30    | 15   | Co-evolution loop gaps (7 items, 7 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap logged) |
+| 🟡 P2    | 30    | 16   | Co-evolution loop gaps (7 items, 7 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap logged) |
 | 🟢 P3    | 24    | 10   | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
 | **Total** | **89** | **45** |
 

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 from datetime import datetime
@@ -90,6 +91,15 @@ class ModelVersionManager:
                 prefix=".version_registry_",
             )
             try:
+                # mkstemp creates the file with mode 0o600 regardless of
+                # umask.  Preserve the existing file's mode (or fall back to
+                # 0o644) so that os.replace doesn't silently tighten
+                # permissions.
+                try:
+                    mode = stat.S_IMODE(os.stat(self.registry_file).st_mode)
+                except OSError:
+                    mode = 0o644
+                os.fchmod(fd, mode)
                 with os.fdopen(fd, "w") as f:
                     json.dump(self.registry, f, indent=2, default=str)
                 os.replace(tmp_path, self.registry_file)
@@ -98,7 +108,6 @@ class ModelVersionManager:
                 # during replace, etc.) so we don't leak orphan files.
                 try:
                     os.unlink(tmp_path)
-                    pass
                 except OSError:
                     pass
                 raise

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -97,13 +97,24 @@ class ModelVersionManager:
                 # permissions.
                 try:
                     mode = stat.S_IMODE(os.stat(self.registry_file).st_mode)
-                except OSError:
+                except FileNotFoundError:
                     mode = 0o644
-                os.fchmod(fd, mode)
+                # os.fchmod is POSIX-only; fall back to os.chmod on Windows.
+                if hasattr(os, "fchmod"):
+                    os.fchmod(fd, mode)
+                else:
+                    os.chmod(tmp_path, mode)
                 with os.fdopen(fd, "w") as f:
+                    fd = -1  # fdopen took ownership; prevent double-close.
                     json.dump(self.registry, f, indent=2, default=str)
                 os.replace(tmp_path, self.registry_file)
             except BaseException:
+                # Close the raw fd if fdopen hasn't taken ownership yet.
+                if fd >= 0:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
                 # Clean up the temp file on any failure (write error, SIGKILL
                 # during replace, etc.) so we don't leak orphan files.
                 try:

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -9,9 +9,11 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -73,11 +75,33 @@ class ModelVersionManager:
             }
 
     def _save_registry(self) -> None:
-        """Save the version registry to disk."""
+        """Save the version registry to disk atomically.
+
+        Writes to a temporary file in the same directory then performs an
+        ``os.replace`` so the registry file is never left in a partially-
+        written state (e.g. after a crash or power loss).
+        """
         try:
             self.registry["updated"] = datetime.now().isoformat()
-            with open(self.registry_file, "w") as f:
-                json.dump(self.registry, f, indent=2, default=str)
+            self.registry_file.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(
+                dir=self.registry_file.parent,
+                suffix=".tmp",
+                prefix=".version_registry_",
+            )
+            try:
+                with os.fdopen(fd, "w") as f:
+                    json.dump(self.registry, f, indent=2, default=str)
+                os.replace(tmp_path, self.registry_file)
+            except BaseException:
+                # Clean up the temp file on any failure (write error, SIGKILL
+                # during replace, etc.) so we don't leak orphan files.
+                try:
+                    os.unlink(tmp_path)
+                    pass
+                except OSError:
+                    pass
+                raise
         except Exception as e:
             logger.error(f"Error saving version registry: {e}")
 

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -81,6 +81,15 @@ class ModelVersionManager:
         Writes to a temporary file in the same directory then performs an
         ``os.replace`` so the registry file is never left in a partially-
         written state (e.g. after a crash or power loss).
+
+        .. note::
+            ``os.replace`` operates on the path itself, not its target.  If
+            ``self.registry_file`` is a symlink, the old write-via-open
+            behaviour preserved the link; the atomic-rename pattern will
+            *replace* the symlink with a regular file.  Callers that point
+            the registry at shared/mounted storage via a symlink should
+            pass the resolved path (e.g. ``Path.realpath(registry_file)``)
+            or avoid symlinks entirely.
         """
         try:
             self.registry["updated"] = datetime.now().isoformat()
@@ -97,7 +106,9 @@ class ModelVersionManager:
                 # permissions.
                 try:
                     mode = stat.S_IMODE(os.stat(self.registry_file).st_mode)
-                except FileNotFoundError:
+                except OSError:
+                    # FileNotFoundError (new registry), PermissionError, or
+                    # any other stat failure — fall back to a sane default.
                     mode = 0o644
                 # os.fchmod is POSIX-only; fall back to os.chmod on Windows.
                 if hasattr(os, "fchmod"):
@@ -113,14 +124,22 @@ class ModelVersionManager:
                 if fd >= 0:
                     try:
                         os.close(fd)
-                    except OSError:
-                        pass
+                    except OSError as exc:
+                        logger.debug(
+                            "Failed to close temp fd %d during cleanup: %s",
+                            fd,
+                            exc,
+                        )
                 # Clean up the temp file on any failure (write error, SIGKILL
                 # during replace, etc.) so we don't leak orphan files.
                 try:
                     os.unlink(tmp_path)
-                except OSError:
-                    pass
+                except OSError as exc:
+                    logger.warning(
+                        "Could not remove temp file %s during cleanup: %s",
+                        tmp_path,
+                        exc,
+                    )
                 raise
         except Exception as e:
             logger.error(f"Error saving version registry: {e}")

--- a/tests/unit/fine_tuning/test_version_manager_atomic_write.py
+++ b/tests/unit/fine_tuning/test_version_manager_atomic_write.py
@@ -1,0 +1,100 @@
+"""Tests for ModelVersionManager atomic registry writes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from evoseal.fine_tuning.version_manager import ModelVersionManager
+
+
+@pytest.fixture
+def versions_dir(tmp_path: Path) -> Path:
+    return tmp_path / "versions"
+
+
+class TestAtomicSaveRegistry:
+    """Verify _save_registry uses atomic temp-file + os.replace."""
+
+    def test_save_creates_registry_file(self, versions_dir: Path) -> None:
+        """Registry file exists and is valid JSON after save."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        vm._save_registry()
+        assert vm.registry_file.exists()
+        data = json.loads(vm.registry_file.read_text())
+        assert "versions" in data
+        assert "created" in data
+        assert "updated" in data
+
+    def test_save_round_trip(self, versions_dir: Path) -> None:
+        """Data written by _save_registry survives a _load_registry round-trip."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        vm.registry["versions"].append({"id": "test-v1", "status": "stored"})
+        vm._save_registry()
+
+        vm2 = ModelVersionManager(versions_dir=versions_dir)
+        assert len(vm2.registry["versions"]) == 1
+        assert vm2.registry["versions"][0]["id"] == "test-v1"
+
+    def test_no_temp_files_left_after_save(self, versions_dir: Path) -> None:
+        """Successful save should not leave temp files behind."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        vm._save_registry()
+
+        tmp_files = list(versions_dir.glob(".version_registry_*"))
+        assert tmp_files == [], f"Orphan temp files found: {tmp_files}"
+
+    def test_write_failure_preserves_original(self, versions_dir: Path) -> None:
+        """If the JSON dump fails, the original file content must be preserved."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        vm.registry["versions"].append({"id": "v1"})
+        vm._save_registry()
+
+        original_content = vm.registry_file.read_text()
+
+        # Simulate a write failure by patching json.dump to raise.
+        with patch(
+            "evoseal.fine_tuning.version_manager.json.dump", side_effect=OSError("disk full")
+        ):
+            vm._save_registry()
+
+        # The original file must still be intact.
+        assert vm.registry_file.read_text() == original_content
+
+    def test_no_temp_files_after_write_failure(self, versions_dir: Path) -> None:
+        """Temp file must be cleaned up even when the write fails."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        vm._save_registry()  # establish the file
+
+        with patch(
+            "evoseal.fine_tuning.version_manager.json.dump", side_effect=OSError("disk full")
+        ):
+            vm._save_registry()
+
+        tmp_files = list(versions_dir.glob(".version_registry_*"))
+        assert tmp_files == [], f"Orphan temp files after failed write: {tmp_files}"
+
+    def test_first_save_to_nonexistent_directory(self, tmp_path: Path) -> None:
+        """First save creates parent directories if needed."""
+        deep_dir = tmp_path / "a" / "b" / "c" / "versions"
+        vm = ModelVersionManager(versions_dir=deep_dir)
+        vm._save_registry()
+        assert vm.registry_file.exists()
+
+    def test_concurrent_reads_see_consistent_data(self, versions_dir: Path) -> None:
+        """A reader loading the file mid-write sees either the old or new
+        version, never a truncated/partial file."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        vm.registry["versions"].append({"id": "v1"})
+        vm._save_registry()
+
+        # Simulate a reader: load the file and check it's valid JSON.
+        # After another save, it should still be valid.
+        vm.registry["versions"].append({"id": "v2"})
+        vm._save_registry()
+
+        data = json.loads(vm.registry_file.read_text())
+        assert len(data["versions"]) == 2

--- a/tests/unit/fine_tuning/test_version_manager_atomic_write.py
+++ b/tests/unit/fine_tuning/test_version_manager_atomic_write.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -98,3 +100,25 @@ class TestAtomicSaveRegistry:
 
         data = json.loads(vm.registry_file.read_text())
         assert len(data["versions"]) == 2
+
+    def test_save_preserves_existing_file_permissions(self, versions_dir: Path) -> None:
+        """Registry file permissions must not tighten after atomic save."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        vm._save_registry()
+
+        # Set a deliberate mode (0o644) and verify it survives a round-trip.
+        os.chmod(vm.registry_file, 0o644)
+        vm.registry["versions"].append({"id": "v1"})
+        vm._save_registry()
+
+        mode = stat.S_IMODE(os.stat(vm.registry_file).st_mode)
+        assert mode == 0o644, f"Expected 0o644 but got {oct(mode)}"
+
+    def test_save_defaults_to_0644_when_file_is_new(self, versions_dir: Path) -> None:
+        """A brand-new registry file should be created with mode 0o644."""
+        vm = ModelVersionManager(versions_dir=versions_dir)
+        # registry_file doesn't exist yet — _save_registry should use 0o644.
+        vm._save_registry()
+
+        mode = stat.S_IMODE(os.stat(vm.registry_file).st_mode)
+        assert mode == 0o644, f"Expected 0o644 but got {oct(mode)}"


### PR DESCRIPTION
## What

`ModelVersionManager._save_registry()` now writes to a temporary file first, then performs an atomic `os.replace()`, so a crash or kill mid-write never leaves the registry file truncated.

## Why

Previously, `_save_registry()` wrote directly via `open(..., "w")` + `json.dump()`. A crash mid-write would truncate the file, and `_load_registry()` silently resets to an empty registry on parse failure — losing all version history with no error surfaced.

This is the **atomic write** item from TODO.md P2.

## Changes

- `evoseal/fine_tuning/version_manager.py`: `_save_registry()` now uses `tempfile.mkstemp()` + `os.replace()` for atomic writes. Temp files are cleaned up on failure. Parent directories are created if needed.
- `tests/unit/fine_tuning/test_version_manager_atomic_write.py`: 7 tests covering round-trip, no orphan temp files, write-failure-preserves-original, and first-save-to-nonexistent-dir.
- `TODO.md`: Flipped checkbox, updated tracking table (P2: 15→16).

## Verification

- `ruff format --check .` ✅
- `ruff check evoseal/ tests/` ✅
- `pytest tests/unit/fine_tuning/ -v` ✅ (64 passed)
- Full `pytest tests/` ✅ (611 passed, 23 deselected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved registry saving to use an atomic temp-file write and replace, preventing truncated or partially written registry files.
  - Preserved existing registry file permissions across saves, and set safe default permissions for new registries.
  - Added/strengthened cleanup to ensure temporary files don’t remain after save success or simulated write failures.
  - Ensures missing directories are created when the registry location doesn’t yet exist.
- **Documentation**
  - Updated the tracking status to mark the registry atomic-write issue as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->