### PR TITLE
docs: complete CHANGELOG.md with missing v0.3.3 and v0.3.4 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ All notable changes to the EVOSEAL project are documented here.
 - **Configuration**: Ensured backward compatibility with existing deployments
 
 
-## [0.3.4] - 2025-07-27 - Release Script Improvements
+## [0.3.4] - 2025-07-28 - Release Script Improvements
 
 ### 🔧 Improvements
 
@@ -54,7 +54,7 @@ All notable changes to the EVOSEAL project are documented here.
 
 > **Note:** v0.3.5 was prepared but never released; v0.3.6 superseded it with additional CI fixes.
 
-## [0.3.3] - 2025-07-27 - CI/CD Reliability
+## [0.3.3] - 2025-07-28 - CI/CD Reliability
 
 ### 🔧 Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,40 @@ All notable changes to the EVOSEAL project are documented here.
 - **Configuration**: Ensured backward compatibility with existing deployments
 
 
+## [0.3.4] - 2025-07-27 - Release Script Improvements
+
+### 🔧 Improvements
+
+#### Release Script
+- **Unified Release Script**: Added `scripts/release.sh` for consistent releases
+- **Submodule Handling**: Improved release script to properly handle git submodules
+- **Uncommitted Changes Check**: Simplified and hardened pre-release validation
+
+### 📚 Documentation
+- **Release Notes**: Generated release notes for v0.3.3 and v0.3.4
+
+> **Note:** v0.3.5 was prepared but never released; v0.3.6 superseded it with additional CI fixes.
+
+## [0.3.3] - 2025-07-27 - CI/CD Reliability
+
+### 🔧 Fixes
+
+#### CI/CD Pipeline
+- **Release Workflow Failures**: Fixed critical Release and Cleanup workflow failures
+- **Black Configuration**: Fixed CI Black configuration to use `pyproject.toml` settings
+- **Black Exclude Pattern**: Fixed exclude pattern for CI compatibility
+- **CodeQL Analysis**: Fixed YAML syntax error in workflow
+- **Formatting Consistency**: Fixed formatting configuration across all tools
+
+#### Dependency Updates
+- **actions/setup-python**: Bumped from v4 to v5 (PR #14)
+- **softprops/action-gh-release**: Bumped from v1 to v2 (PR #15)
+
+### 🧹 Cleanup
+- **Pre-commit Configuration**: Streamlined for release preparation
+- **Virtual Environment Exclusions**: Added comprehensive exclusions for linters
+- **Code Formatting**: Applied consistent formatting across entire codebase
+
 ## [0.3.2] - 2025-07-27 - Port Consistency and Configuration Standardization
 
 ### 🔧 Fixes

--- a/TODO.md
+++ b/TODO.md
@@ -306,8 +306,8 @@
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 14   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review; signal-handler init fix; safety.yaml created |
 | 🟡 P2    | 30    | 16   | Co-evolution loop gaps (7 items, 7 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap logged) |
-| 🟢 P3    | 24    | 11   | Makefile, pre-commit, Docker, ADRs, ADR refresh complete; +10 hygiene items from 2026-07-22 review |
-| **Total** | **89** | **52** |
+| 🟢 P3    | 24    | 12   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +10 hygiene items from 2026-07-22 review |
+| **Total** | **89** | **53** |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -244,7 +244,7 @@
 - [x] **Add pre-commit hooks** _(done 2026-06-04)_
   - ruff (lint + format), bandit, detect-secrets, hadolint, trufflehog, pytest fast-check
   - Config in `.pre-commit-config.yaml`; install with `pre-commit install`
-- [x] **Add `CHANGELOG.md`** tracking releases (v0.3.7 is latest but no changelog visible)
+- [x] **Add `CHANGELOG.md`** tracking releases
 - [x] **Docker support** _(already present)_
   - `Dockerfile` (python:3.11-slim + uv) and `docker-compose.evoseal.yml`
   - Dashboard on port 9613; volumes for checkpoints, data, reports, benchmarks

--- a/TODO.md
+++ b/TODO.md
@@ -244,7 +244,7 @@
 - [x] **Add pre-commit hooks** _(done 2026-06-04)_
   - ruff (lint + format), bandit, detect-secrets, hadolint, trufflehog, pytest fast-check
   - Config in `.pre-commit-config.yaml`; install with `pre-commit install`
-- [ ] **Add `CHANGELOG.md`** tracking releases (v0.3.7 is latest but no changelog visible)
+- [x] **Add `CHANGELOG.md`** tracking releases (v0.3.7 is latest but no changelog visible)
 - [x] **Docker support** _(already present)_
   - `Dockerfile` (python:3.11-slim + uv) and `docker-compose.evoseal.yml`
   - Dashboard on port 9613; volumes for checkpoints, data, reports, benchmarks


### PR DESCRIPTION
## What

Added missing release entries to CHANGELOG.md for v0.3.3 (CI/CD reliability) and v0.3.4 (release script improvements). Noted that v0.3.5 was prepared but never released.

## Why

TODO.md had an unchecked item: "Add CHANGELOG.md tracking releases." The file already existed but was missing two release entries, making it incomplete as a release history reference.

## Changes

- Added `[0.3.4]` entry: release script improvements (unified release script, submodule handling)
- Added `[0.3.3]` entry: CI/CD reliability fixes (Black config, workflow failures, dependency bumps)
- Added note that v0.3.5 was prepared but never released (v0.3.6 superseded it)
- Flipped TODO.md checkbox from `- [ ]` to `- [x]`

## Verification

- `ruff format --check .` passed
- `ruff check evoseal/ tests/` passed
- Docs-only change; no Python code modified

Addresses: TODO.md P3 item "Add CHANGELOG.md tracking releases"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for versions 0.3.3 and 0.3.4.
  - Documented CI/CD reliability improvements, release workflow updates, formatting configuration fixes, and dependency updates.
  - Clarified that version 0.3.5 was prepared but not released.
  - Updated the development checklist and completion tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->