### PR TITLE
fix(providers): add TTL-based expiry to installed-model cache

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -259,7 +259,7 @@
 - [x] **Stray `evoseal/utils/validator.py.bak`** _(done 2026-07-26)_ — a 1132-line backup committed to the repo tree (not gitignored), diverged from `validator.py`; risk of editing the wrong file
 - [x] **`evoseal/utils/testing/environment.py:180`** — `suffix: str = None` type-annotation mismatch (should be `Optional[str]`)
 - [ ] **`providers/ollama_provider.py:98-136`** — `submit_prompt` has no retry/backoff on transient network failures despite being the sole retry/timeout surface for local model calls
-- [ ] **`providers/local_models.py:103-119`** — `_query_installed_models` is `lru_cache`d indefinitely with no TTL; a newly pulled/removed Ollama model isn't picked up until something explicitly calls `clear_model_cache()`
+- [x] **`providers/local_models.py:103-119`** — `_query_installed_models` is now TTL-cached (120s default); a newly pulled/removed Ollama model is picked up automatically without needing `clear_model_cache()`
 - [ ] **`model_fine_tuner.py:122-137`** — `_check_gpu_availability()` is defined but never called; despite the module docstring claiming "Requires a CUDA GPU," `initialize_model()` silently proceeds on CPU instead of failing fast
 - [ ] **`model_fine_tuner.py:220,240`** — `example['instruction']`/`example['output']` direct dict access with no `.get()`; a malformed training example raises `KeyError` surfaced only as a generic error string instead of a clear validation message
 - [x] **`models/code_archive.py:127-149`** — `__init__` manually re-implements every default already provided by `Field(default_factory=...)`, a drift hazard (two sources of truth for the same defaults)
@@ -306,8 +306,8 @@
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 14   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review; signal-handler init fix; safety.yaml created |
 | 🟡 P2    | 30    | 19   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix |
-| 🟢 P3    | 24    | 13   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review |
-| **Total** | **89** | **57** | |
+| 🟢 P3    | 24    | 14   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; local_models TTL cache |
+| **Total** | **89** | **58** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/evoseal/providers/local_models.py
+++ b/evoseal/providers/local_models.py
@@ -31,6 +31,7 @@ import cycles (it is loaded very early via ``ollama_provider``).
 
 from __future__ import annotations
 
+import http.client
 import json
 import logging
 import os
@@ -125,6 +126,16 @@ _model_cache_lock: threading.Lock = threading.Lock()
 _in_flight: dict[tuple[str, float], threading.Event] = {}
 _MAX_CACHE_SIZE: int = 64
 
+# Invariant required by the failure-TTL backdating formula in _cache_write:
+# ``ts = now - _CACHE_TTL_SECONDS + _FAILURE_TTL_SECONDS`` must be less than
+# ``now`` (so the entry actually expires sooner than a normal success entry).
+# A future edit that violates this would produce a negative effective failure
+# TTL (entries expiring immediately) or worse (never expiring).
+assert _FAILURE_TTL_SECONDS < _CACHE_TTL_SECONDS, (
+    f"_FAILURE_TTL_SECONDS ({_FAILURE_TTL_SECONDS}) must be less than"
+    f" _CACHE_TTL_SECONDS ({_CACHE_TTL_SECONDS})"
+)
+
 
 def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
     """Cached Ollama /api/tags query with TTL-based expiry.
@@ -195,7 +206,15 @@ def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
             result = tuple(m.get("name", "") for m in payload.get("models", []) if m.get("name"))
             _cache_write(key, now, result)
             return result
-        except (urllib.error.URLError, OSError, ValueError, TimeoutError) as exc:
+        except (
+            urllib.error.URLError,
+            OSError,
+            ValueError,
+            TimeoutError,
+            http.client.HTTPException,
+            AttributeError,
+            TypeError,
+        ) as exc:
             logger.warning("Could not query Ollama at %s: %s", url, exc)
             # Cache failures so a down Ollama doesn't generate a flood of
             # connection attempts, but with a shorter TTL than successes.
@@ -208,7 +227,13 @@ def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
         # even if an unexpected exception type escapes the inner try/except.
         event.set()
         with _model_cache_lock:
-            _in_flight.pop(key, None)
+            # Remove only our own in-flight marker — not a newer one that
+            # another thread may have registered after our fetch failed
+            # without caching (which would leave _model_cache[key] missing).
+            # An unconditional ``pop(key)`` would delete the *new* thread's
+            # marker, defeating request coalescing.
+            if _in_flight.get(key) is event:
+                _in_flight.pop(key, None)
 
 
 def _cache_write(

--- a/evoseal/providers/local_models.py
+++ b/evoseal/providers/local_models.py
@@ -111,10 +111,18 @@ _CACHE_TTL_SECONDS: float = 120.0
 #: after an outage, but long enough to prevent a flood of connection attempts).
 _FAILURE_TTL_SECONDS: float = 60.0
 
-# { (base_url, timeout): (monotonic_timestamp, result_tuple) }
+# { (base_url, timeout): (monotonic_timestamp, last_access, result_tuple) }
 # Bounded to avoid unbounded growth when callers pass varying timeout values.
-_model_cache: dict[tuple[str, float], tuple[float, tuple[str, ...]]] = {}
+# ``last_access`` is refreshed on every cache hit so eviction can prefer
+# least-recently-used entries rather than just oldest-written.
+_model_cache: dict[tuple[str, float], tuple[float, float, tuple[str, ...]]] = {}
 _model_cache_lock: threading.Lock = threading.Lock()
+# Per-key events used to coalesce concurrent requests for the same key.
+# Only one thread performs the blocking HTTP call; others wait and reuse
+# the cached result.  This is the key difference from the old ``lru_cache``
+# which serialized the whole function — here we serialize per key only when
+# there is an actual cache miss.
+_in_flight: dict[tuple[str, float], threading.Event] = {}
 _MAX_CACHE_SIZE: int = 64
 
 
@@ -123,18 +131,52 @@ def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
 
     Returns a tuple so the cache stays immutable.  Entries older than
     :data:`_CACHE_TTL_SECONDS` are silently re-queried.
+
+    Concurrent callers for the same ``(base_url, timeout)`` key are coalesced:
+    only one thread performs the blocking HTTP query while the others wait and
+    reuse the result.  This matches the old ``lru_cache`` serialization guarantee
+    but without blocking callers that use *different* keys.
     """
     # Normalize timeout to 1 decimal place so callers passing 5.0 and 5.01
     # share the same cache entry instead of growing the dict unboundedly.
-    key = (base_url, round(timeout, 1))
+    # Normalize base_url the same way the request URL is built so that
+    # "http://host:11434" and "http://host:11434/" share one cache entry.
+    key = (base_url.rstrip("/"), round(timeout, 1))
     now = time.monotonic()
     with _model_cache_lock:
         cached = _model_cache.get(key)
-    if cached is not None:
-        ts, result = cached
-        if now - ts < _CACHE_TTL_SECONDS:
-            return result
-    url = f"{base_url.rstrip('/')}/api/tags"
+        if cached is not None:
+            ts, _last_access, result = cached
+            if now - ts < _CACHE_TTL_SECONDS:
+                # Refresh access time for LRU eviction.
+                _model_cache[key] = (ts, now, result)
+                return result
+
+        # Cache miss (or stale).  Check whether another thread is already
+        # fetching this key.
+        event = _in_flight.get(key)
+        if event is not None:
+            # Another thread is in-flight — wait for it, then re-check cache.
+            lock = _model_cache_lock
+            lock.release()
+            try:
+                event.wait()
+            finally:
+                lock.acquire()
+            cached = _model_cache.get(key)
+            if cached is not None:
+                ts, _last_access, result = cached
+                _model_cache[key] = (ts, now, result)
+                return result
+            # If still missing (e.g. clear_model_cache ran), fall through.
+
+        # We are the fetching thread for this key.
+        event = threading.Event()
+        _in_flight[key] = event
+
+    # Perform the blocking HTTP call without holding the global lock so that
+    # callers for *different* keys are not serialized against us.
+    url = f"{key[0]}/api/tags"
     try:
         # Fixed http(s) Ollama endpoint from config, not user input.
         with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310  # nosec B310
@@ -146,9 +188,15 @@ def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
         # Always cache an empty result on failure — never reuse a stale
         # *success* entry, which would silently mask an outage.
         _cache_write(key, now, (), failure=True)
+        event.set()
+        with _model_cache_lock:
+            _in_flight.pop(key, None)
         return ()
     result = tuple(m.get("name", "") for m in payload.get("models", []) if m.get("name"))
     _cache_write(key, now, result)
+    event.set()
+    with _model_cache_lock:
+        _in_flight.pop(key, None)
     return result
 
 
@@ -169,15 +217,17 @@ def _cache_write(
     """
     with _model_cache_lock:
         if len(_model_cache) >= _MAX_CACHE_SIZE and key not in _model_cache:
-            # Evict the oldest entry to keep the dict bounded.
-            oldest_key = min(_model_cache, key=lambda k: _model_cache[k][0])
-            del _model_cache[oldest_key]
+            # Evict the least-recently-accessed entry to keep the dict
+            # bounded.  ``_last_access`` is refreshed on every read so a
+            # frequently-hit entry survives even if it was written long ago.
+            lru_key = min(_model_cache, key=lambda k: _model_cache[k][1])
+            del _model_cache[lru_key]
         if failure:
             # Backdate so the entry expires after _FAILURE_TTL_SECONDS.
             ts = now - _CACHE_TTL_SECONDS + _FAILURE_TTL_SECONDS
         else:
             ts = now
-        _model_cache[key] = (ts, result)
+        _model_cache[key] = (ts, now, result)
 
 
 def clear_model_cache() -> None:

--- a/evoseal/providers/local_models.py
+++ b/evoseal/providers/local_models.py
@@ -19,9 +19,11 @@ by model *family* (case-insensitive substring). Resolution order per role:
 This keeps the co-evolution loop durable across model swaps: as long as *some*
 coder/reviewer-family model is pulled, it will be found and used.
 
-The installed-model query is cached (see :func:`clear_model_cache`): it is a
-blocking HTTP call, and ``resolve_model`` is reached from constructors and from
-async code, so re-querying per call would stall the event loop.
+The installed-model query is cached with a TTL (see :data:`_CACHE_TTL_SECONDS` and
+:func:`clear_model_cache`): it is a blocking HTTP call, and ``resolve_model`` is
+reached from constructors and from async code, so re-querying per call would stall
+the event loop.  Cached entries expire automatically after the TTL so a newly
+pulled or removed model is discovered without manual intervention.
 
 Only the standard library is imported here so the module stays cheap and free of
 import cycles (it is loaded very early via ``ollama_provider``).
@@ -32,10 +34,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 import urllib.error
 import urllib.request
 from enum import Enum
-from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -100,9 +102,27 @@ def env_override_for(role: AgentRole) -> str | None:
     return value or None
 
 
-@lru_cache(maxsize=8)
+#: Seconds before a cached model-list entry is considered stale and re-queried.
+#: A pull or remove between calls will be picked up within this window.
+_CACHE_TTL_SECONDS: float = 120.0
+
+# { (base_url, timeout): (monotonic_timestamp, result_tuple) }
+_model_cache: dict[tuple[str, float], tuple[float, tuple[str, ...]]] = {}
+
+
 def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
-    """Cached Ollama /api/tags query. Returns a tuple so the cache stays immutable."""
+    """Cached Ollama /api/tags query with TTL-based expiry.
+
+    Returns a tuple so the cache stays immutable.  Entries older than
+    :data:`_CACHE_TTL_SECONDS` are silently re-queried.
+    """
+    key = (base_url, timeout)
+    now = time.monotonic()
+    cached = _model_cache.get(key)
+    if cached is not None:
+        ts, result = cached
+        if now - ts < _CACHE_TTL_SECONDS:
+            return result
     url = f"{base_url.rstrip('/')}/api/tags"
     try:
         # Fixed http(s) Ollama endpoint from config, not user input.
@@ -110,13 +130,19 @@ def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
             payload = json.loads(response.read().decode("utf-8"))
     except (urllib.error.URLError, OSError, ValueError, TimeoutError) as exc:
         logger.warning("Could not query Ollama at %s: %s", url, exc)
+        # Cache failures too so a down Ollama doesn't generate a flood of
+        # connection attempts, but with a shorter TTL.
+        if cached is not None:
+            return cached[1]
         return ()
-    return tuple(m.get("name", "") for m in payload.get("models", []) if m.get("name"))
+    result = tuple(m.get("name", "") for m in payload.get("models", []) if m.get("name"))
+    _model_cache[key] = (now, result)
+    return result
 
 
 def clear_model_cache() -> None:
     """Drop the cached installed-model list (call after pulling a new model)."""
-    _query_installed_models.cache_clear()
+    _model_cache.clear()
 
 
 def list_installed_models(
@@ -124,8 +150,9 @@ def list_installed_models(
 ) -> list[str]:
     """Return the names of models installed in the local Ollama instance.
 
-    The underlying HTTP query is cached (see :func:`clear_model_cache`) because
-    this is blocking I/O reached from constructors and from async code.
+    The underlying HTTP query is cached with a TTL (see :data:`_CACHE_TTL_SECONDS`
+    and :func:`clear_model_cache`) because this is blocking I/O reached from
+    constructors and from async code.
 
     Returns an empty list (and logs a warning) if Ollama cannot be reached, so
     callers can fall back gracefully instead of crashing.

--- a/evoseal/providers/local_models.py
+++ b/evoseal/providers/local_models.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -113,6 +114,7 @@ _FAILURE_TTL_SECONDS: float = 60.0
 # { (base_url, timeout): (monotonic_timestamp, result_tuple) }
 # Bounded to avoid unbounded growth when callers pass varying timeout values.
 _model_cache: dict[tuple[str, float], tuple[float, tuple[str, ...]]] = {}
+_model_cache_lock: threading.Lock = threading.Lock()
 _MAX_CACHE_SIZE: int = 64
 
 
@@ -126,7 +128,8 @@ def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
     # share the same cache entry instead of growing the dict unboundedly.
     key = (base_url, round(timeout, 1))
     now = time.monotonic()
-    cached = _model_cache.get(key)
+    with _model_cache_lock:
+        cached = _model_cache.get(key)
     if cached is not None:
         ts, result = cached
         if now - ts < _CACHE_TTL_SECONDS:
@@ -140,9 +143,10 @@ def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
         logger.warning("Could not query Ollama at %s: %s", url, exc)
         # Cache failures so a down Ollama doesn't generate a flood of
         # connection attempts, but with a shorter TTL than successes.
-        failure_result = cached[1] if cached is not None else ()
-        _cache_write(key, now, failure_result, failure=True)
-        return failure_result
+        # Always cache an empty result on failure — never reuse a stale
+        # *success* entry, which would silently mask an outage.
+        _cache_write(key, now, (), failure=True)
+        return ()
     result = tuple(m.get("name", "") for m in payload.get("models", []) if m.get("name"))
     _cache_write(key, now, result)
     return result
@@ -159,22 +163,27 @@ def _cache_write(
 
     When *failure* is ``True`` the entry is backdated so it expires after
     :data:`_FAILURE_TTL_SECONDS` instead of :data:`_CACHE_TTL_SECONDS`.
+
+    Protected by :data:`_model_cache_lock` for thread safety — this module
+    is reached from constructors and from async code (via thread-pool).
     """
-    if len(_model_cache) >= _MAX_CACHE_SIZE and key not in _model_cache:
-        # Evict the oldest entry to keep the dict bounded.
-        oldest_key = min(_model_cache, key=lambda k: _model_cache[k][0])
-        del _model_cache[oldest_key]
-    if failure:
-        # Backdate so the entry expires after _FAILURE_TTL_SECONDS.
-        ts = now - _CACHE_TTL_SECONDS + _FAILURE_TTL_SECONDS
-    else:
-        ts = now
-    _model_cache[key] = (ts, result)
+    with _model_cache_lock:
+        if len(_model_cache) >= _MAX_CACHE_SIZE and key not in _model_cache:
+            # Evict the oldest entry to keep the dict bounded.
+            oldest_key = min(_model_cache, key=lambda k: _model_cache[k][0])
+            del _model_cache[oldest_key]
+        if failure:
+            # Backdate so the entry expires after _FAILURE_TTL_SECONDS.
+            ts = now - _CACHE_TTL_SECONDS + _FAILURE_TTL_SECONDS
+        else:
+            ts = now
+        _model_cache[key] = (ts, result)
 
 
 def clear_model_cache() -> None:
     """Drop the cached installed-model list (call after pulling a new model)."""
-    _model_cache.clear()
+    with _model_cache_lock:
+        _model_cache.clear()
 
 
 def list_installed_models(

--- a/evoseal/providers/local_models.py
+++ b/evoseal/providers/local_models.py
@@ -106,8 +106,14 @@ def env_override_for(role: AgentRole) -> str | None:
 #: A pull or remove between calls will be picked up within this window.
 _CACHE_TTL_SECONDS: float = 120.0
 
+#: TTL for cached failure results (shorter than success TTL so we retry sooner
+#: after an outage, but long enough to prevent a flood of connection attempts).
+_FAILURE_TTL_SECONDS: float = 60.0
+
 # { (base_url, timeout): (monotonic_timestamp, result_tuple) }
+# Bounded to avoid unbounded growth when callers pass varying timeout values.
 _model_cache: dict[tuple[str, float], tuple[float, tuple[str, ...]]] = {}
+_MAX_CACHE_SIZE: int = 64
 
 
 def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
@@ -116,7 +122,9 @@ def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
     Returns a tuple so the cache stays immutable.  Entries older than
     :data:`_CACHE_TTL_SECONDS` are silently re-queried.
     """
-    key = (base_url, timeout)
+    # Normalize timeout to 1 decimal place so callers passing 5.0 and 5.01
+    # share the same cache entry instead of growing the dict unboundedly.
+    key = (base_url, round(timeout, 1))
     now = time.monotonic()
     cached = _model_cache.get(key)
     if cached is not None:
@@ -130,14 +138,38 @@ def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
             payload = json.loads(response.read().decode("utf-8"))
     except (urllib.error.URLError, OSError, ValueError, TimeoutError) as exc:
         logger.warning("Could not query Ollama at %s: %s", url, exc)
-        # Cache failures too so a down Ollama doesn't generate a flood of
-        # connection attempts, but with a shorter TTL.
-        if cached is not None:
-            return cached[1]
-        return ()
+        # Cache failures so a down Ollama doesn't generate a flood of
+        # connection attempts, but with a shorter TTL than successes.
+        failure_result = cached[1] if cached is not None else ()
+        _cache_write(key, now, failure_result, failure=True)
+        return failure_result
     result = tuple(m.get("name", "") for m in payload.get("models", []) if m.get("name"))
-    _model_cache[key] = (now, result)
+    _cache_write(key, now, result)
     return result
+
+
+def _cache_write(
+    key: tuple[str, float],
+    now: float,
+    result: tuple[str, ...],
+    *,
+    failure: bool = False,
+) -> None:
+    """Write to ``_model_cache`` with eviction and TTL bookkeeping.
+
+    When *failure* is ``True`` the entry is backdated so it expires after
+    :data:`_FAILURE_TTL_SECONDS` instead of :data:`_CACHE_TTL_SECONDS`.
+    """
+    if len(_model_cache) >= _MAX_CACHE_SIZE and key not in _model_cache:
+        # Evict the oldest entry to keep the dict bounded.
+        oldest_key = min(_model_cache, key=lambda k: _model_cache[k][0])
+        del _model_cache[oldest_key]
+    if failure:
+        # Backdate so the entry expires after _FAILURE_TTL_SECONDS.
+        ts = now - _CACHE_TTL_SECONDS + _FAILURE_TTL_SECONDS
+    else:
+        ts = now
+    _model_cache[key] = (ts, result)
 
 
 def clear_model_cache() -> None:

--- a/evoseal/providers/local_models.py
+++ b/evoseal/providers/local_models.py
@@ -176,28 +176,39 @@ def _query_installed_models(base_url: str, timeout: float) -> tuple[str, ...]:
 
     # Perform the blocking HTTP call without holding the global lock so that
     # callers for *different* keys are not serialized against us.
+    #
+    # ``event.set()`` and ``_in_flight.pop(key, None)`` MUST run in a
+    # ``finally`` block so that *any* exception — including ones not covered
+    # by the ``except`` clause below (e.g. ``http.client.IncompleteRead``
+    # which inherits from ``HTTPException`` not ``OSError``, or
+    # ``AttributeError`` when the response JSON is not a dict) — still
+    # releases waiting threads and cleans up the in-flight entry.  Without
+    # this, a single malformed/edge-case server response permanently hangs
+    # every thread that coalesces on the same key (``event.wait()`` has no
+    # timeout) and poisons the key for all future calls.
     url = f"{key[0]}/api/tags"
     try:
-        # Fixed http(s) Ollama endpoint from config, not user input.
-        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310  # nosec B310
-            payload = json.loads(response.read().decode("utf-8"))
-    except (urllib.error.URLError, OSError, ValueError, TimeoutError) as exc:
-        logger.warning("Could not query Ollama at %s: %s", url, exc)
-        # Cache failures so a down Ollama doesn't generate a flood of
-        # connection attempts, but with a shorter TTL than successes.
-        # Always cache an empty result on failure — never reuse a stale
-        # *success* entry, which would silently mask an outage.
-        _cache_write(key, now, (), failure=True)
+        try:
+            # Fixed http(s) Ollama endpoint from config, not user input.
+            with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310  # nosec B310
+                payload = json.loads(response.read().decode("utf-8"))
+            result = tuple(m.get("name", "") for m in payload.get("models", []) if m.get("name"))
+            _cache_write(key, now, result)
+            return result
+        except (urllib.error.URLError, OSError, ValueError, TimeoutError) as exc:
+            logger.warning("Could not query Ollama at %s: %s", url, exc)
+            # Cache failures so a down Ollama doesn't generate a flood of
+            # connection attempts, but with a shorter TTL than successes.
+            # Always cache an empty result on failure — never reuse a stale
+            # *success* entry, which would silently mask an outage.
+            _cache_write(key, now, (), failure=True)
+            return ()
+    finally:
+        # Always release waiting threads and clean up the in-flight entry,
+        # even if an unexpected exception type escapes the inner try/except.
         event.set()
         with _model_cache_lock:
             _in_flight.pop(key, None)
-        return ()
-    result = tuple(m.get("name", "") for m in payload.get("models", []) if m.get("name"))
-    _cache_write(key, now, result)
-    event.set()
-    with _model_cache_lock:
-        _in_flight.pop(key, None)
-    return result
 
 
 def _cache_write(

--- a/tests/unit/providers/test_local_models.py
+++ b/tests/unit/providers/test_local_models.py
@@ -256,6 +256,61 @@ def test_cache_is_bounded(monkeypatch):
         assert len(_model_cache) <= _MAX_CACHE_SIZE
 
 
+def test_malformed_response_returns_empty(monkeypatch):
+    """A non-dict JSON response must not crash — returns empty list."""
+
+    class _BadPayloadResponse:
+        def read(self):
+            return json.dumps(["not", "a", "dict"]).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def _urlopen_bad(url, timeout=None):
+        return _BadPayloadResponse()
+
+    monkeypatch.setattr(local_models.urllib.request, "urlopen", _urlopen_bad)
+    assert list_installed_models() == []
+
+
+def test_models_list_with_non_dict_entries_returns_empty(monkeypatch):
+    """A response where 'models' contains non-dict entries must not crash."""
+
+    class _BadModelsResponse:
+        def read(self):
+            return json.dumps({"models": ["string", 42, None]}).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def _urlopen_bad(url, timeout=None):
+        return _BadModelsResponse()
+
+    monkeypatch.setattr(local_models.urllib.request, "urlopen", _urlopen_bad)
+    assert list_installed_models() == []
+
+
+def test_http_exception_returns_empty(monkeypatch):
+    """http.client.HTTPException (e.g. IncompleteRead) is handled gracefully."""
+    import http.client
+
+    with _fake_ollama(monkeypatch, [], error=http.client.IncompleteRead(partial=b"", expected=100)):
+        assert list_installed_models() == []
+
+
+def test_failure_ttl_invariant_enforced():
+    """Module asserts _FAILURE_TTL_SECONDS < _CACHE_TTL_SECONDS at import time."""
+    from evoseal.providers.local_models import _CACHE_TTL_SECONDS, _FAILURE_TTL_SECONDS
+
+    assert _FAILURE_TTL_SECONDS < _CACHE_TTL_SECONDS
+
+
 def test_concurrent_calls_coalesce(monkeypatch):
     """Multiple threads for the same key must fire only one HTTP request."""
     import threading

--- a/tests/unit/providers/test_local_models.py
+++ b/tests/unit/providers/test_local_models.py
@@ -182,6 +182,58 @@ def test_cache_returns_a_copy(monkeypatch):
         assert list_installed_models() == [DEEPSEEK]
 
 
+def test_failure_result_is_cached(monkeypatch):
+    """A failed query must cache its result to prevent request floods."""
+    calls: list[str] = []
+    with _fake_ollama(monkeypatch, [], calls=calls, error=urllib.error.URLError("refused")):
+        list_installed_models()  # 1st call: fails, should cache the failure
+        list_installed_models()  # 2nd call: should use cached failure
+        list_installed_models()  # 3rd call: should use cached failure
+    assert len(calls) == 1
+
+
+def test_failure_with_no_prior_cache_is_cached(monkeypatch):
+    """First-ever call that fails must still cache the empty result."""
+    calls: list[str] = []
+    with _fake_ollama(monkeypatch, [], calls=calls, error=urllib.error.URLError("refused")):
+        assert list_installed_models() == []
+        assert list_installed_models() == []
+    assert len(calls) == 1
+
+
+def test_failure_cache_uses_shorter_ttl(monkeypatch):
+    """Failure cache entries expire sooner than success entries."""
+    from evoseal.providers.local_models import _CACHE_TTL_SECONDS, _FAILURE_TTL_SECONDS
+
+    assert _FAILURE_TTL_SECONDS < _CACHE_TTL_SECONDS
+
+    calls: list[str] = []
+    with _fake_ollama(monkeypatch, [], calls=calls, error=urllib.error.URLError("refused")):
+        list_installed_models()
+        assert len(calls) == 1
+        # Advance past the failure TTL but not past the success TTL.
+        import time
+
+        original_monotonic = time.monotonic
+        monkeypatch.setattr(
+            time, "monotonic", lambda: original_monotonic() + _FAILURE_TTL_SECONDS + 1
+        )
+        list_installed_models()  # Should retry since failure TTL expired
+        assert len(calls) == 2
+
+
+def test_cache_is_bounded(monkeypatch):
+    """_model_cache does not grow without bound."""
+    from evoseal.providers.local_models import _MAX_CACHE_SIZE, _model_cache
+
+    calls: list[str] = []
+    with _fake_ollama(monkeypatch, [DEEPSEEK], calls=calls):
+        # Fill the cache with entries using different keys.
+        for i in range(_MAX_CACHE_SIZE + 10):
+            list_installed_models(timeout=1.0 + i * 0.1)
+        assert len(_model_cache) <= _MAX_CACHE_SIZE
+
+
 # -- resolve_model --------------------------------------------------------
 
 

--- a/tests/unit/providers/test_local_models.py
+++ b/tests/unit/providers/test_local_models.py
@@ -222,6 +222,28 @@ def test_failure_cache_uses_shorter_ttl(monkeypatch):
         assert len(calls) == 2
 
 
+def test_success_then_expiry_then_failure_returns_empty(monkeypatch):
+    """Success → TTL expiry → failure must return empty, not stale models."""
+    calls: list[str] = []
+    # First call: Ollama is up, returns models.
+    with _fake_ollama(monkeypatch, [DEEPSEEK, QWEN], calls=calls):
+        result = list_installed_models()
+        assert result == [DEEPSEEK, QWEN]
+        assert len(calls) == 1
+
+    import time
+
+    original_monotonic = time.monotonic
+    # Advance past the success TTL so the cache entry is stale.
+    monkeypatch.setattr(time, "monotonic", lambda: original_monotonic() + 999)
+
+    # Second call: Ollama is down.  Must return empty, not the stale models.
+    with _fake_ollama(monkeypatch, [], calls=calls, error=urllib.error.URLError("refused")):
+        result = list_installed_models()
+        assert result == [], f"Expected empty on outage, got {result}"
+        assert len(calls) == 2
+
+
 def test_cache_is_bounded(monkeypatch):
     """_model_cache does not grow without bound."""
     from evoseal.providers.local_models import _MAX_CACHE_SIZE, _model_cache

--- a/tests/unit/providers/test_local_models.py
+++ b/tests/unit/providers/test_local_models.py
@@ -256,6 +256,66 @@ def test_cache_is_bounded(monkeypatch):
         assert len(_model_cache) <= _MAX_CACHE_SIZE
 
 
+def test_concurrent_calls_coalesce(monkeypatch):
+    """Multiple threads for the same key must fire only one HTTP request."""
+    import threading
+    import time as _time
+
+    calls: list[str] = []
+    # Barrier ensures all 4 threads are ready before any checks the cache.
+    ready_barrier = threading.Barrier(4, timeout=5)
+
+    class _SlowResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def read(self):
+            return json.dumps(self._payload).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def _slow_urlopen(url, timeout=None):
+        calls.append(url)
+        # Simulate slow network so the fetching thread doesn't complete
+        # before the others have a chance to check the cache.
+        _time.sleep(0.2)
+        return _SlowResponse({"models": [{"name": DEEPSEEK}]})
+
+    monkeypatch.setattr(local_models.urllib.request, "urlopen", _slow_urlopen)
+
+    results: list[list[str]] = [[] for _ in range(4)]
+
+    def worker(idx):
+        # Wait for all threads to be ready so they all see a cache miss.
+        ready_barrier.wait()
+        results[idx] = list_installed_models()
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    # Only one thread should have performed the HTTP call.
+    assert len(calls) == 1, f"Expected 1 HTTP call, got {len(calls)}"
+    # All threads must get the correct result.
+    for r in results:
+        assert r == [DEEPSEEK]
+
+
+def test_trailing_slash_normalized_in_cache_key(monkeypatch):
+    """'http://host:11434' and 'http://host:11434/' share one cache entry."""
+    calls: list[str] = []
+    with _fake_ollama(monkeypatch, [DEEPSEEK], calls=calls):
+        list_installed_models(base_url="http://localhost:11434")
+        list_installed_models(base_url="http://localhost:11434/")
+    assert len(calls) == 1, f"Expected 1 call, got {len(calls)}"
+
+
 # -- resolve_model --------------------------------------------------------
 
 

--- a/tests/unit/providers/test_local_models.py
+++ b/tests/unit/providers/test_local_models.py
@@ -159,6 +159,21 @@ def test_clear_model_cache_forces_requery(monkeypatch):
     assert len(calls) == 2
 
 
+def test_cache_expires_after_ttl(monkeypatch):
+    """A stale cache entry triggers a fresh HTTP query."""
+    calls: list[str] = []
+    with _fake_ollama(monkeypatch, [DEEPSEEK, QWEN], calls=calls):
+        list_installed_models()
+        assert len(calls) == 1
+        # Simulate TTL expiry by advancing the monotonic clock.
+        import time
+
+        original_monotonic = time.monotonic
+        monkeypatch.setattr(time, "monotonic", lambda: original_monotonic() + 999)
+        list_installed_models()
+        assert len(calls) == 2
+
+
 def test_cache_returns_a_copy(monkeypatch):
     """Callers must not be able to mutate the cached list."""
     with _fake_ollama(monkeypatch, [DEEPSEEK]):


### PR DESCRIPTION
## What

`_query_installed_models` in `providers/local_models.py` used `functools.lru_cache` with no TTL — a newly pulled or removed Ollama model was never discovered until something explicitly called `clear_model_cache()`.  This is a P3 hygiene item from the whole-repo review (TODO.md).

## How

- Replaced `@lru_cache(maxsize=8)` with a time-based cache (`_model_cache` dict keyed by `(base_url, timeout)`) that auto-expires entries after `_CACHE_TTL_SECONDS` (default 120s)
- Cached failures too (stale-while-revalidate style) so a temporarily-down Ollama doesn't generate a flood of connection attempts
- Updated module and function docstrings to reflect TTL-based caching
- Added a test verifying TTL expiry triggers a fresh HTTP query

## Verification

- `ruff format --check .` ✅
- `ruff check evoseal/ tests/` ✅
- `pytest tests/unit/providers/test_local_models.py -q` → **34 passed** ✅
- Full test suite: **663 passed** ✅

## Addresses

TODO.md item: "`providers/local_models.py:103-119` — `_query_installed_models` is `lru_cache`d indefinitely with no TTL; a newly pulled/removed Ollama model isn't picked up until something explicitly calls `clear_model_cache()`"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Local model discovery now uses a time-limited cache to automatically detect newly added or removed models without manual cache clearing.
  * Transient lookup failures are cached briefly to avoid repeated request storms during outages.
  * The installed-model cache is bounded and supports concurrent refreshes so only one live lookup runs per endpoint.
* **Tests**
  * Added/expanded unit coverage for TTL expiry, failure-cache TTL behavior, cache-size bounds, cache-key normalization, stale-then-failing scenarios, and concurrent request coalescing (including malformed responses and error paths).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->