### PR TITLE
test: add regression tests for config validation edge cases

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -199,7 +199,7 @@
 - [ ] **Increase unit test coverage for `core/` modules**
   - `controller.py`, `evaluator.py`, `selection.py`, `version_database.py`
   - Target: meaningful coverage on core logic paths, not just line count
-- [ ] **Add regression test for config validation**
+- [x] **Add regression test for config validation**
   - Malformed YAML, missing required sections, type mismatches
 - [ ] **Add test for checkpoint save/restore**
   - Interrupt mid-evolution, restore from checkpoint, verify state consistency
@@ -305,9 +305,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 14   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review; signal-handler init fix; safety.yaml created |
-| 🟡 P2    | 30    | 19   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix |
+| 🟡 P2    | 30    | 20   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix |
 | 🟢 P3    | 24    | 15   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache |
-| **Total** | **89** | **59** | |
+| **Total** | **89** | **60** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/tests/unit/models/test_system_config.py
+++ b/tests/unit/models/test_system_config.py
@@ -118,6 +118,22 @@ def test_validate_with_none_values_for_required_keys():
     assert sys_config.validate() is True
 
 
+def test_validate_with_type_mismatch_for_required_keys():
+    """Required keys present but with wrong types should still validate.
+
+    validate() only checks key presence, not value type — a string, list,
+    or int in place of a dict must not cause validation failure.
+    """
+    config = {
+        "dgm": "not a dict",
+        "openevolve": [1, 2, 3],
+        "seal": 42,
+        "integration": True,
+    }
+    sys_config = SystemConfig(config)
+    assert sys_config.validate() is True
+
+
 def test_validate_extra_keys_accepted():
     """Extra keys beyond REQUIRED_KEYS should not cause validation failure."""
     config = {

--- a/tests/unit/models/test_system_config.py
+++ b/tests/unit/models/test_system_config.py
@@ -141,10 +141,14 @@ def test_get_through_non_dict_intermediate_returns_default():
 
 
 def test_get_with_numeric_key_in_path():
-    """Dot notation with numeric-looking string keys works correctly."""
-    config = {"port": 8080, "servers": {"0": {"host": "localhost"}}}
+    """Dot notation traverses dict keys that look numeric (e.g. '0').
+
+    This tests dict-key traversal only — 'servers' is a dict with a string
+    key '0', not a list.  If get() ever adds list-index support, this test
+    ensures a numeric-looking dict key is still treated as a string lookup.
+    """
+    config = {"servers": {"0": {"host": "localhost"}}}
     sys_config = SystemConfig(config)
-    assert sys_config.get("port") == 8080
     assert sys_config.get("servers.0.host") == "localhost"
 
 

--- a/tests/unit/models/test_system_config.py
+++ b/tests/unit/models/test_system_config.py
@@ -88,3 +88,102 @@ def test_from_yaml_malformed_syntax_raises():
             SystemConfig.from_yaml(yaml_path)
     finally:
         os.remove(yaml_path)
+
+
+# --- Regression tests for config validation edge cases ---
+
+
+def test_from_yaml_file_not_found():
+    """from_yaml raises FileNotFoundError for a nonexistent path."""
+    with pytest.raises(FileNotFoundError, match="not found"):
+        SystemConfig.from_yaml("/nonexistent/path/config.yaml")
+
+
+def test_from_yaml_comments_only_raises():
+    """A YAML file with only comments parses as None → rejected as non-mapping."""
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        f.write("# just a comment\n# another comment\n")
+        yaml_path = f.name
+    try:
+        with pytest.raises(ValueError, match="did not produce a mapping"):
+            SystemConfig.from_yaml(yaml_path)
+    finally:
+        os.remove(yaml_path)
+
+
+def test_validate_with_none_values_for_required_keys():
+    """Required keys present but set to None should still validate (section exists)."""
+    config = {"dgm": None, "openevolve": None, "seal": None, "integration": None}
+    sys_config = SystemConfig(config)
+    assert sys_config.validate() is True
+
+
+def test_validate_extra_keys_accepted():
+    """Extra keys beyond REQUIRED_KEYS should not cause validation failure."""
+    config = {
+        "dgm": {},
+        "openevolve": {},
+        "seal": {},
+        "integration": {},
+        "custom_section": {"foo": 1},
+        "another": [1, 2, 3],
+    }
+    sys_config = SystemConfig(config)
+    assert sys_config.validate() is True
+
+
+def test_get_through_non_dict_intermediate_returns_default():
+    """Dot-notation access through a non-dict intermediate value returns default."""
+    config = {"a": "a_string_value"}
+    sys_config = SystemConfig(config)
+    # "a" exists but is a string, not a dict — accessing "a.b" should return default
+    assert sys_config.get("a.b", "fallback") == "fallback"
+
+
+def test_get_with_numeric_key_in_path():
+    """Dot notation with numeric-looking string keys works correctly."""
+    config = {"port": 8080, "servers": {"0": {"host": "localhost"}}}
+    sys_config = SystemConfig(config)
+    assert sys_config.get("port") == 8080
+    assert sys_config.get("servers.0.host") == "localhost"
+
+
+def test_get_none_value_vs_missing():
+    """An explicitly-set None value is returned; a missing key returns the default."""
+    config = {"key": None}
+    sys_config = SystemConfig(config)
+    assert sys_config.get("key") is None
+    assert sys_config.get("key", "default") is None  # key exists, value is None
+    assert sys_config.get("missing", "default") == "default"  # key absent
+
+
+def test_validate_multiple_missing_sections():
+    """Multiple missing sections are all reported in the error message."""
+    config = {"dgm": {}}
+    sys_config = SystemConfig(config)
+    with pytest.raises(ValueError) as e:
+        sys_config.validate()
+    msg = str(e.value)
+    for section in ["openevolve", "seal", "integration"]:
+        assert section in msg
+
+
+def test_from_yaml_deeply_nested_config():
+    """A deeply nested but valid YAML config loads and dot-notation traverses it."""
+    config = {
+        "dgm": {"settings": {"mutation": {"rate": 0.1, "strategy": "uniform"}}},
+        "openevolve": {},
+        "seal": {},
+        "integration": {},
+    }
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        yaml.dump(config, f)
+        yaml_path = f.name
+    try:
+        sys_config = SystemConfig.from_yaml(yaml_path)
+        assert sys_config.validate() is True
+        assert sys_config.get("dgm.settings.mutation.rate") == 0.1
+        assert sys_config.get("dgm.settings.mutation.strategy") == "uniform"
+        assert sys_config.get("dgm.settings.mutation.unknown", "x") == "x"
+    finally:
+        os.remove(yaml_path)


### PR DESCRIPTION
## What

Adds 9 new regression tests to `tests/unit/models/test_system_config.py` for `SystemConfig` validation edge cases:

- `test_from_yaml_file_not_found` — nonexistent path raises `FileNotFoundError`
- `test_from_yaml_comments_only_raises` — YAML with only comments parses as None, correctly rejected
- `test_validate_with_none_values_for_required_keys` — None values for required sections still validate (section key exists)
- `test_validate_extra_keys_accepted` — extra keys beyond REQUIRED_KEYS do not cause failure
- `test_get_through_non_dict_intermediate_returns_default` — dot-notation traversal through a non-dict intermediate returns default
- `test_get_with_numeric_key_in_path` — numeric-looking string keys in dot notation
- `test_get_none_value_vs_missing` — explicit None vs missing key distinction in get()
- `test_validate_multiple_missing_sections` — all missing sections reported in error
- `test_from_yaml_deeply_nested_config` — deeply nested YAML load and traversal

## Why

Addresses TODO.md P2 item: **Add regression test for config validation** — malformed YAML, missing required sections, type mismatches. These edge cases catch regressions in the from_yaml, validate, and get pipeline that the existing 7 tests do not cover.

## Verification

- ruff format --check: passed
- ruff check evoseal/ tests/: passed
- pytest tests/unit/models/test_system_config.py -v: 16/16 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for configuration loading, validation, and nested value access.
  * Verified handling of missing files, comments-only YAML, deeply nested settings, optional values, extra keys, numeric keys, and missing paths.
  * Confirmed validation errors report all missing required sections.

* **Documentation**
  * Updated task tracking to reflect completion of configuration validation test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->