### PR TITLE
fix: call _check_gpu_availability() in initialize_model to fail fast without GPU

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -260,7 +260,7 @@
 - [x] **`evoseal/utils/testing/environment.py:180`** — `suffix: str = None` type-annotation mismatch (should be `Optional[str]`)
 - [x] **`providers/ollama_provider.py:98-136`** — `submit_prompt` has no retry/backoff on transient network failures despite being the sole retry/timeout surface for local model calls
 - [x] **`providers/local_models.py:103-119`** — `_query_installed_models` is now TTL-cached (120s default); a newly pulled/removed Ollama model is picked up automatically without needing `clear_model_cache()`
-- [ ] **`model_fine_tuner.py:122-137`** — `_check_gpu_availability()` is defined but never called; despite the module docstring claiming "Requires a CUDA GPU," `initialize_model()` silently proceeds on CPU instead of failing fast
+- [x] **`model_fine_tuner.py:122-137`** — `_check_gpu_availability()` was defined but never called; `initialize_model()` now calls it and returns `False` with a clear error when no CUDA GPU is available
 - [ ] **`model_fine_tuner.py:220,240`** — `example['instruction']`/`example['output']` direct dict access with no `.get()`; a malformed training example raises `KeyError` surfaced only as a generic error string instead of a clear validation message
 - [x] **`models/code_archive.py:127-149`** — `__init__` manually re-implements every default already provided by `Field(default_factory=...)`, a drift hazard (two sources of truth for the same defaults)
 - [x] **`evoseal/agents/agentic_system_example.py:7`** — `from evoseal.agentic_system import ...` is the wrong module path (actual: `evoseal.agents.agentic_system`); the example fails immediately with `ModuleNotFoundError`
@@ -306,8 +306,8 @@
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 14   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review; signal-handler init fix; safety.yaml created |
 | 🟡 P2    | 30    | 20   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix |
-| 🟢 P3    | 24    | 15   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache |
-| **Total** | **89** | **60** | |
+| 🟢 P3    | 24    | 16   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache |
+| **Total** | **89** | **61** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/evoseal/fine_tuning/model_fine_tuner.py
+++ b/evoseal/fine_tuning/model_fine_tuner.py
@@ -137,7 +137,8 @@ class ModelFineTuner:
             import torch
 
             return torch.cuda.is_available() and torch.cuda.device_count() > 0
-        except Exception:
+        except Exception as e:
+            logger.debug("GPU check failed: %s", e)
             return False
 
     async def initialize_model(self) -> bool:

--- a/evoseal/fine_tuning/model_fine_tuner.py
+++ b/evoseal/fine_tuning/model_fine_tuner.py
@@ -138,7 +138,7 @@ class ModelFineTuner:
 
             return torch.cuda.is_available() and torch.cuda.device_count() > 0
         except Exception as e:
-            logger.debug("GPU check failed: %s", e)
+            logger.warning("GPU check failed: %s", e)
             return False
 
     async def initialize_model(self) -> bool:

--- a/evoseal/fine_tuning/model_fine_tuner.py
+++ b/evoseal/fine_tuning/model_fine_tuner.py
@@ -147,6 +147,13 @@ class ModelFineTuner:
             logger.error("Transformers library not available for fine-tuning")
             return False
 
+        if not self._check_gpu_availability():
+            logger.error(
+                "No CUDA GPU available; model fine-tuning requires a GPU. "
+                "Use the prompt-level path (evoseal.prompt_evolution) on CPU-only hosts."
+            )
+            return False
+
         try:
             logger.info("Initializing model and tokenizer...")
 

--- a/evoseal/fine_tuning/model_fine_tuner.py
+++ b/evoseal/fine_tuning/model_fine_tuner.py
@@ -121,10 +121,14 @@ class ModelFineTuner:
 
     def _check_gpu_availability(self) -> bool:
         """
-        Check if GPU is available for training.
+        Check if a CUDA GPU is available for training.
+
+        Only NVIDIA CUDA is checked; ROCm and MPS backends are not
+        considered. This is intentional: the fine-tuning codepath relies
+        on CUDA-specific features (torch.cuda, device_map="auto", fp16).
 
         Returns:
-            True if GPU is available, False otherwise
+            True if a CUDA GPU is available, False otherwise
         """
         if not TRANSFORMERS_AVAILABLE:
             return False
@@ -133,7 +137,7 @@ class ModelFineTuner:
             import torch
 
             return torch.cuda.is_available() and torch.cuda.device_count() > 0
-        except ImportError:
+        except Exception:
             return False
 
     async def initialize_model(self) -> bool:
@@ -149,8 +153,9 @@ class ModelFineTuner:
 
         if not self._check_gpu_availability():
             logger.error(
-                "No CUDA GPU available; model fine-tuning requires a GPU. "
-                "Use the prompt-level path (evoseal.prompt_evolution) on CPU-only hosts."
+                "No CUDA GPU available; model fine-tuning requires a CUDA GPU "
+                "(ROCm and MPS are not currently supported). "
+                "Use the prompt-level path (evoseal.prompt_evolution) on non-CUDA hosts."
             )
             return False
 

--- a/tests/unit/fine_tuning/test_model_fine_tuner.py
+++ b/tests/unit/fine_tuning/test_model_fine_tuner.py
@@ -9,7 +9,7 @@ already-tokenized dataset untouched.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from datasets import Dataset
@@ -60,3 +60,44 @@ class TestTokenizeIfNeeded:
 
         _, kwargs = fine_tuner.tokenizer.call_args
         assert kwargs["max_length"] == 128
+
+
+class TestInitializeModelGpuGuard:
+    """Regression tests for the _check_gpu_availability early-exit path."""
+
+    @pytest.fixture()
+    def fine_tuner(self):
+        ft = ModelFineTuner.__new__(ModelFineTuner)
+        ft.model_name = "test-model"
+        ft.is_initialized = False
+        ft.model = None
+        ft.tokenizer = None
+        return ft
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_gpu_unavailable(self, fine_tuner):
+        import evoseal.fine_tuning.model_fine_tuner as mod
+
+        with (
+            patch.object(mod, "TRANSFORMERS_AVAILABLE", True),
+            patch.object(ModelFineTuner, "_check_gpu_availability", return_value=False),
+        ):
+            result = await fine_tuner.initialize_model()
+
+        assert result is False
+        assert fine_tuner.is_initialized is False
+
+    @pytest.mark.asyncio
+    async def test_does_not_load_model_when_gpu_unavailable(self, fine_tuner):
+        import evoseal.fine_tuning.model_fine_tuner as mod
+
+        with (
+            patch.object(mod, "TRANSFORMERS_AVAILABLE", True),
+            patch.object(ModelFineTuner, "_check_gpu_availability", return_value=False),
+            patch.object(mod, "AutoTokenizer", create=True) as mock_tok,
+            patch.object(mod, "AutoModelForCausalLM", create=True) as mock_model,
+        ):
+            await fine_tuner.initialize_model()
+
+        mock_tok.from_pretrained.assert_not_called()
+        mock_model.from_pretrained.assert_not_called()

--- a/tests/unit/fine_tuning/test_model_fine_tuner.py
+++ b/tests/unit/fine_tuning/test_model_fine_tuner.py
@@ -105,7 +105,7 @@ class TestInitializeModelGpuGuard:
     def test_gpu_check_returns_false_on_runtime_error(self, fine_tuner):
         """_check_gpu_availability catches non-ImportError exceptions (e.g. driver
         failures) and returns False instead of letting them propagate."""
-        import torch
+        torch = pytest.importorskip("torch")
 
         import evoseal.fine_tuning.model_fine_tuner as mod
 

--- a/tests/unit/fine_tuning/test_model_fine_tuner.py
+++ b/tests/unit/fine_tuning/test_model_fine_tuner.py
@@ -101,3 +101,18 @@ class TestInitializeModelGpuGuard:
 
         mock_tok.from_pretrained.assert_not_called()
         mock_model.from_pretrained.assert_not_called()
+
+    def test_gpu_check_returns_false_on_runtime_error(self, fine_tuner):
+        """_check_gpu_availability catches non-ImportError exceptions (e.g. driver
+        failures) and returns False instead of letting them propagate."""
+        import torch
+
+        import evoseal.fine_tuning.model_fine_tuner as mod
+
+        with (
+            patch.object(mod, "TRANSFORMERS_AVAILABLE", True),
+            patch.object(torch.cuda, "is_available", side_effect=RuntimeError("CUDA driver error")),
+        ):
+            result = fine_tuner._check_gpu_availability()
+
+        assert result is False


### PR DESCRIPTION
## What

`initialize_model()` in `model_fine_tuner.py` now calls the existing `_check_gpu_availability()` method before attempting to load a model. If no CUDA GPU is available, it returns `False` with a clear error message directing users to the prompt-level path (`evoseal.prompt_evolution`).

## Why

The method `_check_gpu_availability()` was defined (lines 122-137) but never called. The module docstring explicitly says "Requires a CUDA GPU" and directs CPU-only hosts to use the prompt-level path, but `initialize_model()` silently proceeded on CPU — potentially very slow or producing unexpected results.

## Verification

- `ruff format --check .` ✅
- `ruff check evoseal/ tests/` ✅
- `pytest tests/unit/fine_tuning/ -q` → 69 passed ✅

Closes TODO.md item: `model_fine_tuner.py:122-137`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fine-tuning now verifies NVIDIA CUDA GPU availability before model initialization and fails fast with a clear error when none is available.
  * GPU checks are now explicitly limited to NVIDIA CUDA; non-CUDA paths are directed to the CPU/prompt-based workflow.
* **Documentation**
  * Updated the task tracking checklist and completed item counts to reflect the new GPU-availability handling.
* **Tests**
  * Added unit test coverage to ensure initialization is skipped and model/tokenizer loading does not occur when GPU availability is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->