### PR TITLE
fix: add asyncio.Lock to protect concurrent registry mutation in ModelVersionManager

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -211,7 +211,7 @@
 
 - [x] **`bidirectional_manager.py` state fields are never mutated** _(done 2026-07-23)_ — fixed by `run_loop_cycle()` in item #6 above; `stats`, `evolution_history`, `is_running`, and `last_check_time` are now all mutated each cycle.
 - [x] **`version_manager.py` registry file has no atomic write** — `_save_registry()` (lines 70-77, PR #72 branch) writes directly via `open(...,"w")` + `json.dump`; a crash/kill mid-write leaves a truncated file, and `_load_registry()` silently resets to an empty registry on parse failure, losing all version history
-- [ ] **`version_manager.py` has no locking around concurrent registry mutation** — overlapping `register_version`/`deploy_version` calls can interleave writes to `self.registry["versions"]`, risking lost updates or an inconsistent `current_version`
+- [x] **`version_manager.py` has no locking around concurrent registry mutation** _(done 2026-08-01)_ — overlapping `register_version`/`deploy_version` calls can interleave writes to `self.registry["versions"]`, risking lost updates or an inconsistent `current_version`. Fixed with `asyncio.Lock` + impl pattern (public methods acquire lock, delegate to `_impl` to avoid reentrant deadlock)
 - [x] **`model_fine_tuner.py:160-178` uses `trust_remote_code=True`** _(done 2026-07-31)_ — changed both `AutoTokenizer` and `AutoModelForCausalLM.from_pretrained` calls to `trust_remote_code=False` (the safe default). The `# nosec B615` suppression comments remain because B615 flags missing `revision=`, not `trust_remote_code`; revision pinning is left to the caller.
 - [x] **`provider_manager.py` treats unhealthy providers as healthy when called from a running event loop** _(done 2026-07-28)_ — `get_best_available_provider()` (lines 100-111) and `list_providers()` (lines 196-201) create a health-check task via `loop.create_task(...)` but never await/consume it, then unconditionally set `is_healthy = True`, discarding the real result; the orphaned task can also produce unretrieved-exception warnings
 - [x] **`agentic_system.py:28` logger bypasses the logging handler hierarchy** _(done 2026-07-26)_ — `Logger("AgenticSystem")` was instantiated directly instead of via `logging.getLogger(name)`; `self.parent` stayed `None`, no handlers attached, and all INFO-level agent-orchestration logs were silently dropped. Changed to `get_logger("AgenticSystem")` to participate in the handler hierarchy
@@ -307,9 +307,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 15   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review; signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix |
-| 🟡 P2    | 30    | 22   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix |
+| 🟡 P2    | 30    | 23   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix |
 | 🟢 P3    | 24    | 16   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions |
-| **Total** | **89** | **64** | |
+| **Total** | **89** | **65** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/evoseal/fine_tuning/version_manager.py
+++ b/evoseal/fine_tuning/version_manager.py
@@ -51,6 +51,11 @@ class ModelVersionManager:
         # Load existing registry
         self.registry = self._load_registry()
 
+        # Async lock protecting registry read-modify-write sequences so that
+        # concurrent ``register_version`` / ``deploy_version`` calls cannot
+        # interleave and corrupt the registry or lose updates.
+        self._lock = asyncio.Lock()
+
         logger.info(
             f"ModelVersionManager initialized with {len(self.registry.get('versions', []))} versions"
         )
@@ -154,8 +159,9 @@ class ModelVersionManager:
         deploy: bool = False,
         ollama_model_name: str | None = None,
     ) -> dict[str, Any]:
-        """
-        Register a new model version.
+        """Register a new model version.
+
+        Thread-safe: concurrent calls are serialised via an internal lock.
 
         Args:
             training_results: Results from model training
@@ -166,6 +172,27 @@ class ModelVersionManager:
         Returns:
             Version information
         """
+        async with self._lock:
+            return await self._register_version_impl(
+                training_results,
+                validation_results,
+                data_prep_results,
+                version_name,
+                deploy=deploy,
+                ollama_model_name=ollama_model_name,
+            )
+
+    async def _register_version_impl(
+        self,
+        training_results: dict[str, Any],
+        validation_results: dict[str, Any] | None = None,
+        data_prep_results: dict[str, Any] | None = None,
+        version_name: str | None = None,
+        *,
+        deploy: bool = False,
+        ollama_model_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Internal implementation of :meth:`register_version` (no lock)."""
         try:
             timestamp = datetime.now()
 
@@ -226,10 +253,13 @@ class ModelVersionManager:
 
             logger.info(f"Registered model version {version_id} ({version_name})")
 
-            # Deploy to Ollama if requested and model files are available
+            # Deploy to Ollama if requested and model files are available.
+            # Call the lock-free impl directly — the caller already holds
+            # ``self._lock``, so going through the public ``deploy_version``
+            # would deadlock.
             if deploy and version_info.get("model_path"):
                 try:
-                    deploy_result = await self.deploy_version(
+                    deploy_result = await self._deploy_version_impl(
                         version_id, ollama_model_name=ollama_model_name
                     )
                 except Exception as deploy_exc:
@@ -357,11 +387,9 @@ class ModelVersionManager:
         version_id: str,
         ollama_model_name: str | None = None,
     ) -> dict[str, Any]:
-        """
-        Deploy a registered model version to Ollama.
+        """Deploy a registered model version to Ollama.
 
-        Creates a Modelfile and runs ``ollama create`` so the serving layer
-        (OllamaProvider) can load the fine-tuned model.
+        Thread-safe: concurrent calls are serialised via an internal lock.
 
         Args:
             version_id: Version ID to deploy
@@ -370,6 +398,15 @@ class ModelVersionManager:
         Returns:
             Deployment result dict with 'ollama_model' on success or 'error'
         """
+        async with self._lock:
+            return await self._deploy_version_impl(version_id, ollama_model_name)
+
+    async def _deploy_version_impl(
+        self,
+        version_id: str,
+        ollama_model_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Internal implementation of :meth:`deploy_version` (no lock)."""
         # Look up the entry directly in the registry list so mutations
         # (deployment_status, ollama_model_name, etc.) are guaranteed to
         # land in self.registry and survive _save_registry(), regardless of

--- a/tests/unit/fine_tuning/test_version_manager_concurrency.py
+++ b/tests/unit/fine_tuning/test_version_manager_concurrency.py
@@ -1,0 +1,131 @@
+"""Tests for asyncio.Lock-based concurrency protection in ModelVersionManager."""
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from evoseal.fine_tuning.version_manager import ModelVersionManager
+
+
+@pytest.fixture
+def versions_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "versions"
+    d.mkdir()
+    return d
+
+
+def _make_training_results(idx: int) -> dict:
+    return {
+        "model_name": f"test-model-{idx}",
+        "train_loss": 0.5 - idx * 0.01,
+        "training_examples_count": 100 + idx,
+    }
+
+
+class TestConcurrentLocking:
+    """Verify that concurrent async calls do not corrupt the registry."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_register_versions_all_persisted(self, versions_dir: Path) -> None:
+        """Multiple concurrent register_version calls must all appear in the registry."""
+        mgr = ModelVersionManager(versions_dir=versions_dir)
+
+        # Patch deploy to avoid calling ollama
+        with patch.object(mgr, "_deploy_to_ollama", return_value=None):
+            tasks = [mgr.register_version(_make_training_results(i)) for i in range(5)]
+            results = await asyncio.gather(*tasks)
+
+        # All 5 should succeed
+        assert all("error" not in r for r in results)
+        assert len(mgr.registry["versions"]) == 5
+
+        # Reload from disk and verify persistence
+        mgr2 = ModelVersionManager(versions_dir=versions_dir)
+        assert len(mgr2.registry["versions"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_concurrent_register_and_deploy_no_corruption(self, versions_dir: Path) -> None:
+        """Interleaved register + deploy must not lose updates or produce inconsistent state."""
+        mgr = ModelVersionManager(versions_dir=versions_dir)
+
+        # First register a version so deploy_version has something to work with
+        with patch.object(mgr, "_deploy_to_ollama", return_value=None):
+            first = await mgr.register_version(_make_training_results(0))
+        first_id = first["version_id"]
+
+        # Now register more versions concurrently with deploying the first.
+        # Deploy will fail (no model_path) — that's fine; the test verifies
+        # the registry stays consistent, not that deploy succeeds.
+        with patch.object(mgr, "_deploy_to_ollama", return_value=None):
+            tasks = [
+                mgr.deploy_version(first_id),
+                *[mgr.register_version(_make_training_results(i + 1)) for i in range(4)],
+            ]
+            results = await asyncio.gather(*tasks)
+
+        # Total versions: 1 (first) + 4 (concurrent) = 5
+        assert len(mgr.registry["versions"]) == 5
+        # deploy_version returned an error (no model files) — that's expected
+        assert "error" in results[0]
+        # All 4 register calls should succeed
+        assert all("error" not in r for r in results[1:])
+
+    @pytest.mark.asyncio
+    async def test_lock_is_per_instance(self, versions_dir: Path) -> None:
+        """Two different ModelVersionManager instances have independent locks."""
+        dir_a = versions_dir / "a"
+        dir_b = versions_dir / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        mgr_a = ModelVersionManager(versions_dir=dir_a)
+        mgr_b = ModelVersionManager(versions_dir=dir_b)
+
+        # They should be able to run concurrently (different locks)
+        with (
+            patch.object(mgr_a, "_deploy_to_ollama", return_value=None),
+            patch.object(mgr_b, "_deploy_to_ollama", return_value=None),
+        ):
+            results = await asyncio.gather(
+                mgr_a.register_version(_make_training_results(0)),
+                mgr_b.register_version(_make_training_results(1)),
+            )
+
+        assert all("error" not in r for r in results)
+        assert len(mgr_a.registry["versions"]) == 1
+        assert len(mgr_b.registry["versions"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_register_then_deploy_serialised(self, versions_dir: Path) -> None:
+        """register_version with deploy=True calls deploy under the same lock
+        without deadlocking (the impl pattern avoids reentrant lock)."""
+        mgr = ModelVersionManager(versions_dir=versions_dir)
+
+        with patch.object(mgr, "_deploy_to_ollama", return_value=None):
+            result = await mgr.register_version(_make_training_results(0), deploy=True)
+
+        assert "error" not in result
+        assert len(mgr.registry["versions"]) == 1
+        # Should have been deployed (or at least attempted)
+        assert result.get("deployment_status") in ("deployed", "failed", "current")
+
+    @pytest.mark.asyncio
+    async def test_deploy_nonexistent_version_while_registering(self, versions_dir: Path) -> None:
+        """A failed deploy (version not found) alongside a register must not corrupt state."""
+        mgr = ModelVersionManager(versions_dir=versions_dir)
+
+        with patch.object(mgr, "_deploy_to_ollama", return_value=None):
+            tasks = [
+                mgr.deploy_version("nonexistent-id"),
+                mgr.register_version(_make_training_results(0)),
+            ]
+            results = await asyncio.gather(*tasks)
+
+        # deploy should fail, register should succeed
+        assert "error" in results[0]
+        assert "error" not in results[1]
+        assert len(mgr.registry["versions"]) == 1


### PR DESCRIPTION
## What

`ModelVersionManager.register_version()` and `deploy_version()` both read-modify-write `self.registry` without synchronisation. Overlapping async calls (e.g. from `BidirectionalEvolutionManager.run_loop_cycle()`) can interleave and corrupt the registry or lose updates.

## How

- Added `asyncio.Lock` to `ModelVersionManager.__init__`
- Public `register_version` and `deploy_version` acquire the lock, then delegate to private `_register_version_impl` / `_deploy_version_impl` (avoids reentrant deadlock since `register_version` internally calls `deploy_version`)
- Complementary to the atomic-write fix (PR #72): this lock prevents interleaved in-memory mutations; `os.replace` prevents torn on-disk writes

## Tests

5 new concurrency tests in `test_version_manager_concurrency.py`:
1. Concurrent `register_version` calls all persist to registry and disk
2. Interleaved `register_version` + `deploy_version` stays consistent
3. Per-instance isolation (independent locks)
4. `register_version(deploy=True)` doesn't deadlock (impl pattern)
5. Failed deploy alongside register doesn't corrupt state

All 47 version_manager tests pass (42 existing + 5 new).

## Addresses

TODO.md item: "`version_manager.py` has no locking around concurrent registry mutation"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when registering and deploying model versions concurrently.
  * Prevented deadlocks during registration-triggered deployments.
  * Preserved consistent registry state and expected deployment errors under simultaneous operations.

* **Tests**
  * Added coverage for concurrent registrations, interleaved registration and deployment, independent manager instances, and nonexistent versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->