### PR TITLE
fix(ci): correct workflow_run trigger names, security gate, and docs dependency path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,6 @@ jobs:
   security:
     name: Security Checks
     needs: [validate, test]  # Run after validate and test
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:  # Allow manual triggering
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI/CD Pipeline"]
     branches: [main, 'release/*']
     types: [completed]
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI/CD Pipeline"]
     branches: [main, 'release/*']
     types: [completed]
   schedule:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Deploy Documentation
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI/CD Pipeline"]
     branches: [main, 'release/*']
     types: [completed]
   workflow_dispatch:  # Manual trigger
@@ -53,19 +53,11 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Cache dependencies
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-docs-${{ hashFiles('requirements/docs.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-docs-
-            ${{ runner.os }}-pip-
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements/docs.txt
+      - name: Install documentation dependencies
+        run: uv pip install --system -e ".[docs]"
 
       - name: Setup Pages
         id: pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Install documentation dependencies
         run: uv pip install --system -e ".[docs]"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -2,7 +2,7 @@ name: Pre-Release (RC)
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI/CD Pipeline"]
     branches: [main, 'release/*']
     types: [completed]
   workflow_dispatch:  # Manual trigger from GitHub UI/API

--- a/TODO.md
+++ b/TODO.md
@@ -136,9 +136,9 @@
 ### CI/CD & Release Pipeline Issues Found in Whole-Repo Code Review (2026-07-22)
 
 - [ ] **Release pipeline is broken** _(exact failure mode needs re-verification — flagged by initial review pass, not yet deep-dived)_
-- [ ] **Some `workflow_run` triggers reference the wrong workflow name**, so dependent workflows don't actually fire when expected
-- [ ] **A `requirements/` directory referenced by tooling/CI does not exist**
-- [ ] **Security-scan gate is defeated by `continue-on-error: true`**, so a failing security check doesn't actually block anything
+- [x] **Some `workflow_run` triggers reference the wrong workflow name** _(done 2026-08-01)_ — `cleanup.yml`, `docs.yml`, `pre-release.yml`, and `codeql-analysis.yml` all referenced `workflows: ["CI"]` but the actual CI workflow name is `"CI/CD Pipeline"`; updated all four to match. Only `release.yml` already had the correct reference.
+- [x] **A `requirements/` directory referenced by tooling/CI does not exist** _(done 2026-08-01)_ — `docs.yml` cached and installed from `requirements/docs.txt` which didn't exist; replaced with `uv pip install --system -e ".[docs]"` matching how the main CI job installs doc dependencies (the `[docs]` extras are defined in `pyproject.toml`). No other workflows reference `requirements/`.
+- [x] **Security-scan gate is defeated by `continue-on-error: true`** _(done 2026-08-01)_ — removed `continue-on-error: true` from the `security` job in `ci.yml` so bandit/safety failures now properly block the `build` and `container` downstream jobs. The remaining `continue-on-error: true` on the mypy lint step is intentional (type checking is advisory).
 
 ### DGM/OpenEvolve Adapter Issues Found in Whole-Repo Code Review (2026-07-22)
 
@@ -306,10 +306,10 @@
 | Priority | Total | Done | Notes |
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
-| 🟠 P1    | 24    | 15   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review; signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix |
+| 🟠 P1    | 24    | 17   | Original safety/integration items done; +11 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix |
 | 🟡 P2    | 30    | 24   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix; safety-decision orchestration tests |
 | 🟢 P3    | 24    | 19   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions; how-it-works tutorial; model_fine_tuner key validation; model_fine_tuner GPU availability check |
-| **Total** | **89** | **69** | |
+| **Total** | **89** | **71** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -306,10 +306,10 @@
 | Priority | Total | Done | Notes |
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
-| 🟠 P1    | 24    | 17   | Original safety/integration items done; +11 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix |
+| 🟠 P1    | 24    | 18   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix |
 | 🟡 P2    | 30    | 24   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix; safety-decision orchestration tests |
 | 🟢 P3    | 24    | 19   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions; how-it-works tutorial; model_fine_tuner key validation; model_fine_tuner GPU availability check |
-| **Total** | **89** | **71** | |
+| **Total** | **89** | **72** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >


### PR DESCRIPTION
## What

Fixes three CI/CD pipeline issues from the TODO.md P1 section:

1. **`workflow_run` triggers reference wrong workflow name** — `cleanup.yml`, `docs.yml`, `pre-release.yml`, and `codeql-analysis.yml` all triggered on `workflows: ["CI"]` but the actual CI workflow is named `"CI/CD Pipeline"`. These four dependent workflows never fired automatically from CI completion. Only `release.yml` already had the correct reference.

2. **Security-scan gate defeated by `continue-on-error: true`** — the `security` job in `ci.yml` had `continue-on-error: true` at the job level, so bandit/safety failures were silently swallowed and didn't block the `build` or `container` downstream jobs. Removed it. (The remaining `continue-on-error: true` on the mypy lint step is intentional — type checking is advisory.)

3. **`requirements/docs.txt` doesn't exist** — `docs.yml` cached and installed from `requirements/docs.txt` but the `requirements/` directory doesn't exist. Replaced with `uv pip install --system -e ".[docs]"` matching how the main CI job installs doc dependencies (the `[docs]` extras are defined in `pyproject.toml`).

## Why

These are all bugs that prevent the CI/CD pipeline from working as designed:
- Dependent workflows (docs deploy, cleanup, pre-release, CodeQL) silently never trigger after CI passes
- Security findings don't block releases
- The docs deployment workflow always fails on the dependency install step

## Verification

- All `workflow_run` triggers now reference `"CI/CD Pipeline"` consistently (verified with grep)
- No `requirements/` references remain in any workflow (verified with grep)
- Only one `continue-on-error: true` remains in CI — on the mypy step, which is intentional
- No Python files changed, so ruff/pytest not applicable

Addresses TODO.md items: "Some `workflow_run` triggers reference the wrong workflow name", "A `requirements/` directory referenced by tooling/CI does not exist", "Security-scan gate is defeated by `continue-on-error: true`"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Security-check failures now correctly prevent successful builds and downstream release activities.
  - Documentation, cleanup, code analysis, and pre-release tasks now run after the correct CI/CD pipeline completes.
  - Documentation builds now use a more reliable dependency installation process.

- **Chores**
  - Updated project tracking to reflect completed CI/CD maintenance items and current completion totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->