### PR TITLE
fix(seal): add async search method to KnowledgeBase for EnhancedSealSystem compatibility

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -152,7 +152,7 @@
 
 ### SEAL Subsystem Issues Found in Whole-Repo Code Review (2026-07-22)
 
-- [ ] **Knowledge retrieval in the SEAL subsystem is broken** _(exact file:line needs re-verification — flagged by initial review pass, not yet deep-dived)_
+- [x] **Knowledge retrieval in the SEAL subsystem is broken** _(done 2026-08-06)_ — `enhanced_seal_system.py:467` called `await self.knowledge_base.search(query=..., max_results=..., min_score=..., context=...)` but `KnowledgeBase` only had `search_entries(query, tags, metadata, limit)` — different method name, different parameter names, and neither method was async so the `await` would raise `TypeError`. Added async `search()` method to `KnowledgeBase` that accepts the expected parameters, delegates to `search_entries`, and converts `KnowledgeEntry` objects to plain dicts matching what callers expect
 
 ---
 
@@ -306,10 +306,10 @@
 | Priority | Total | Done | Notes |
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
-| 🟠 P1    | 24    | 18   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix |
+| 🟠 P1    | 24    | 19   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix; SEAL knowledge retrieval API mismatch fix |
 | 🟡 P2    | 30    | 25   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix; safety-decision orchestration tests; structured improvement units |
 | 🟢 P3    | 24    | 19   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions; how-it-works tutorial; model_fine_tuner key validation; model_fine_tuner GPU availability check |
-| **Total** | **89** | **73** | |
+| **Total** | **89** | **74** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -152,7 +152,7 @@
 
 ### SEAL Subsystem Issues Found in Whole-Repo Code Review (2026-07-22)
 
-- [x] **Knowledge retrieval in the SEAL subsystem is broken** _(done 2026-08-06)_ — `enhanced_seal_system.py:467` called `await self.knowledge_base.search(query=..., max_results=..., min_score=..., context=...)` but `KnowledgeBase` only had `search_entries(query, tags, metadata, limit)` — different method name, different parameter names, and neither method was async so the `await` would raise `TypeError`. Added async `search()` method to `KnowledgeBase` that accepts the expected parameters, delegates to `search_entries`, and converts `KnowledgeEntry` objects to plain dicts matching what callers expect
+- [x] **Knowledge retrieval in the SEAL subsystem is broken** _(done 2026-08-06)_ — `enhanced_seal_system.py:467` called `await self.knowledge_base.search(query=..., max_results=..., min_score=..., context=...)` but `KnowledgeBase` only had `search_entries(query, tags, metadata, limit)` — different method name, different parameter names, `search` was missing so the call raised `AttributeError`; awaiting a synchronous `search_entries(...)` result would raise `TypeError`. Added async `search()` method to `KnowledgeBase` that accepts the expected parameters, delegates to `search_entries`, and converts `KnowledgeEntry` objects to plain dicts matching what callers expect
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -153,6 +153,7 @@
 ### SEAL Subsystem Issues Found in Whole-Repo Code Review (2026-07-22)
 
 - [x] **Knowledge retrieval in the SEAL subsystem is broken** _(done 2026-08-06)_ — `enhanced_seal_system.py:467` called `await self.knowledge_base.search(query=..., max_results=..., min_score=..., context=...)` but `KnowledgeBase` only had `search_entries(query, tags, metadata, limit)` — different method name, different parameter names, `search` was missing so the call raised `AttributeError`; awaiting a synchronous `search_entries(...)` result would raise `TypeError`. Added async `search()` method to `KnowledgeBase` that accepts the expected parameters, delegates to `search_entries`, and converts `KnowledgeEntry` objects to plain dicts matching what callers expect
+- [ ] **KnowledgeBase.search() score-based filtering/ranking** — follow-up to the above. `search()` returns `score: 1.0` for every entry, so `min_score` filtering is a no-op and score-based ranking in `prompt/formatters.py` treats all matches as equally relevant. Implement a real relevance score (e.g. occurrence count, match position, or TF-IDF) and filter by `min_score` so callers get meaningful ranking.
 
 ---
 

--- a/evoseal/integration/seal/knowledge/knowledge_base.py
+++ b/evoseal/integration/seal/knowledge/knowledge_base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import fcntl
 import json
+import logging
 import os
 import tempfile
 import time
@@ -447,6 +448,8 @@ class KnowledgeBase:
         with self._lock:
             return len(self.entries)
 
+    _logger: logging.Logger | None = None
+
     async def search(
         self,
         query: str,
@@ -471,13 +474,29 @@ class KnowledgeBase:
         min_score:
             Accepted for API compatibility with ``MockKnowledgeBase`` but
             not used by the real implementation (entries are matched by
-            substring, not scored).
+            substring, not scored).  A warning is logged when a non-default
+            value is supplied so callers migrating from the mock do not
+            silently lose filtering.
         context:
             Accepted for API compatibility; not used by the current
             implementation.
         """
+        if min_score is not None:
+            if self._logger is None:
+                self._logger = logging.getLogger(__name__)
+            self._logger.warning(
+                "min_score=%s was passed to KnowledgeBase.search() but the real "
+                "implementation uses substring matching and does not filter by "
+                "score. All matches will be returned regardless of this value.",
+                min_score,
+            )
+
+        if max_results is not None and max_results < 0:
+            max_results = 0
+
         limit = max_results if max_results is not None else self.DEFAULT_SEARCH_LIMIT
-        entries = self.search_entries(query=query, limit=limit)
+        with self._lock:
+            entries = self.search_entries(query=query, limit=limit)
         return [
             {
                 "id": entry.id,
@@ -485,8 +504,12 @@ class KnowledgeBase:
                 "score": 1.0,  # real KB uses substring matching, no scoring
                 "metadata": entry.metadata,
                 "tags": entry.tags,
-                "created_at": entry.created_at.isoformat(),
-                "updated_at": entry.updated_at.isoformat(),
+                "created_at": entry.created_at.isoformat()
+                if entry.created_at is not None
+                else None,
+                "updated_at": entry.updated_at.isoformat()
+                if entry.updated_at is not None
+                else None,
             }
             for entry in entries
         ]

--- a/evoseal/integration/seal/knowledge/knowledge_base.py
+++ b/evoseal/integration/seal/knowledge/knowledge_base.py
@@ -447,6 +447,50 @@ class KnowledgeBase:
         with self._lock:
             return len(self.entries)
 
+    async def search(
+        self,
+        query: str,
+        max_results: int | None = None,
+        min_score: float | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Search for knowledge entries matching a query.
+
+        This is the async interface used by ``EnhancedSealSystem`` and other
+        async callers.  It delegates to :meth:`search_entries` and converts
+        the results to plain dicts so the return type matches what callers
+        expect (``list[dict[str, Any]]``).
+
+        Parameters
+        ----------
+        query:
+            Free-text query to search against entry content.
+        max_results:
+            Maximum number of results to return.  Defaults to
+            ``DEFAULT_SEARCH_LIMIT``.
+        min_score:
+            Accepted for API compatibility with ``MockKnowledgeBase`` but
+            not used by the real implementation (entries are matched by
+            substring, not scored).
+        context:
+            Accepted for API compatibility; not used by the current
+            implementation.
+        """
+        limit = max_results if max_results is not None else self.DEFAULT_SEARCH_LIMIT
+        entries = self.search_entries(query=query, limit=limit)
+        return [
+            {
+                "id": entry.id,
+                "content": entry.content,
+                "score": 1.0,  # real KB uses substring matching, no scoring
+                "metadata": entry.metadata,
+                "tags": entry.tags,
+                "created_at": entry.created_at.isoformat(),
+                "updated_at": entry.updated_at.isoformat(),
+            }
+            for entry in entries
+        ]
+
     def get_all_entries(self) -> list[KnowledgeEntry]:
         """Get all entries in the knowledge base.
 

--- a/evoseal/integration/seal/knowledge/knowledge_base.py
+++ b/evoseal/integration/seal/knowledge/knowledge_base.py
@@ -449,7 +449,6 @@ class KnowledgeBase:
             return len(self.entries)
 
     _logger: logging.Logger | None = None
-    _MOCK_DEFAULT_MIN_SCORE: float = 0.3
 
     async def search(
         self,
@@ -465,6 +464,14 @@ class KnowledgeBase:
         the results to plain dicts so the return type matches what callers
         expect (``list[dict[str, Any]]``).
 
+        TODO: ``min_score`` is accepted for API compatibility but has no real
+        effect — all matches are returned with a hardcoded score of ``1.0``.
+        Downstream code that sorts or filters by score (e.g.
+        ``prompt/formatters.py``) will treat every match as maximally
+        relevant.  Implementing a rudimentary relevance score (e.g.
+        occurrence count or match position) would make ``min_score``
+        filtering and score-based ranking functional.
+
         Parameters
         ----------
         query:
@@ -475,14 +482,14 @@ class KnowledgeBase:
         min_score:
             Accepted for API compatibility with ``MockKnowledgeBase`` but
             not used by the real implementation (entries are matched by
-            substring, not scored).  A warning is logged when a value other
-            than the mock's default (0.3) is supplied so callers migrating
-            from the mock do not silently lose filtering.
+            substring, not scored).  A warning is logged when any value is
+            supplied so callers migrating from the mock do not silently
+            lose filtering.
         context:
             Accepted for API compatibility; not used by the current
             implementation.
         """
-        if min_score is not None and min_score != self._MOCK_DEFAULT_MIN_SCORE:
+        if min_score is not None:
             if self._logger is None:
                 self._logger = logging.getLogger(__name__)
             self._logger.warning(
@@ -508,7 +515,9 @@ class KnowledgeBase:
             {
                 "id": entry.id,
                 "content": entry.content,
-                "score": 1.0,  # real KB uses substring matching, no scoring
+                # TODO: Replace with a real relevance score so min_score
+                # filtering and score-based ranking work.  See search() docstring.
+                "score": 1.0,
                 "metadata": entry.metadata,
                 "tags": entry.tags,
                 "created_at": entry.created_at.isoformat()

--- a/evoseal/integration/seal/knowledge/knowledge_base.py
+++ b/evoseal/integration/seal/knowledge/knowledge_base.py
@@ -449,6 +449,7 @@ class KnowledgeBase:
             return len(self.entries)
 
     _logger: logging.Logger | None = None
+    _MOCK_DEFAULT_MIN_SCORE: float = 0.3
 
     async def search(
         self,
@@ -474,14 +475,14 @@ class KnowledgeBase:
         min_score:
             Accepted for API compatibility with ``MockKnowledgeBase`` but
             not used by the real implementation (entries are matched by
-            substring, not scored).  A warning is logged when a non-default
-            value is supplied so callers migrating from the mock do not
-            silently lose filtering.
+            substring, not scored).  A warning is logged when a value other
+            than the mock's default (0.3) is supplied so callers migrating
+            from the mock do not silently lose filtering.
         context:
             Accepted for API compatibility; not used by the current
             implementation.
         """
-        if min_score is not None:
+        if min_score is not None and min_score != self._MOCK_DEFAULT_MIN_SCORE:
             if self._logger is None:
                 self._logger = logging.getLogger(__name__)
             self._logger.warning(
@@ -491,10 +492,16 @@ class KnowledgeBase:
                 min_score,
             )
 
+        # Negative max_results is a caller bug — raise rather than silently
+        # clamping or (worse) passing a negative limit through to search_entries.
         if max_results is not None and max_results < 0:
-            max_results = 0
+            raise ValueError(f"max_results must be non-negative, got {max_results}")
 
         limit = max_results if max_results is not None else self.DEFAULT_SEARCH_LIMIT
+        # NOTE: self._lock is a threading.RLock, not an asyncio.Lock, so this
+        # blocks the event loop for the duration of the in-memory scan.  This
+        # is acceptable because search_entries is a fast dict iteration + slice
+        # and does not perform I/O.
         with self._lock:
             entries = self.search_entries(query=query, limit=limit)
         return [

--- a/evoseal/integration/seal/knowledge/knowledge_base.py
+++ b/evoseal/integration/seal/knowledge/knowledge_base.py
@@ -7,6 +7,7 @@ of knowledge in the SEAL system.
 
 from __future__ import annotations
 
+import asyncio
 import fcntl
 import json
 import logging
@@ -505,12 +506,12 @@ class KnowledgeBase:
             raise ValueError(f"max_results must be non-negative, got {max_results}")
 
         limit = max_results if max_results is not None else self.DEFAULT_SEARCH_LIMIT
-        # NOTE: self._lock is a threading.RLock, not an asyncio.Lock, so this
-        # blocks the event loop for the duration of the in-memory scan.  This
-        # is acceptable because search_entries is a fast dict iteration + slice
-        # and does not perform I/O.
-        with self._lock:
-            entries = self.search_entries(query=query, limit=limit)
+        # self._lock is a threading.RLock, not an asyncio.Lock, and
+        # search_entries does an O(n) in-memory scan.  Running that
+        # directly would block the event loop for the full duration,
+        # stalling any concurrent coroutines.  Offload to a thread so
+        # the event loop remains responsive.
+        entries = await asyncio.to_thread(self._search_entries_sync, query, limit)
         return [
             {
                 "id": entry.id,
@@ -529,6 +530,15 @@ class KnowledgeBase:
             }
             for entry in entries
         ]
+
+    def _search_entries_sync(self, query: str | None, limit: int) -> list[KnowledgeEntry]:
+        """Synchronous helper that acquires the lock and runs search_entries.
+
+        Called via ``asyncio.to_thread`` from :meth:`search` so the event
+        loop is not blocked by the in-memory scan.
+        """
+        with self._lock:
+            return self.search_entries(query=query, limit=limit)
 
     def get_all_entries(self) -> list[KnowledgeEntry]:
         """Get all entries in the knowledge base.

--- a/evoseal/integration/seal/knowledge/knowledge_base.py
+++ b/evoseal/integration/seal/knowledge/knowledge_base.py
@@ -22,6 +22,8 @@ from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
+logger = logging.getLogger(__name__)
+
 
 class KnowledgeEntry(BaseModel):
     """Represents a single entry in the knowledge base."""
@@ -449,8 +451,6 @@ class KnowledgeBase:
         with self._lock:
             return len(self.entries)
 
-    _logger: logging.Logger | None = None
-
     async def search(
         self,
         query: str,
@@ -491,9 +491,7 @@ class KnowledgeBase:
             implementation.
         """
         if min_score is not None:
-            if self._logger is None:
-                self._logger = logging.getLogger(__name__)
-            self._logger.warning(
+            logger.warning(
                 "min_score=%s was passed to KnowledgeBase.search() but the real "
                 "implementation uses substring matching and does not filter by "
                 "score. All matches will be returned regardless of this value.",

--- a/tests/integration/seal/test_knowledge_base.py
+++ b/tests/integration/seal/test_knowledge_base.py
@@ -1,8 +1,11 @@
 """Tests for the KnowledgeBase class."""
 
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Final
+
+import pytest
 
 from evoseal.integration.seal.knowledge.knowledge_base import KnowledgeBase, KnowledgeEntry
 
@@ -171,3 +174,44 @@ def test_clear(tmp_path):
     assert len(kb) == EXPECTED_ENTRIES_AFTER_ADD
     kb.clear()
     assert len(kb) == EXPECTED_ENTRIES_AFTER_DELETE
+
+
+@pytest.mark.asyncio
+async def test_search_min_score_none_no_warning(tmp_path, caplog):
+    """search(min_score=None) should not log a warning."""
+    kb = KnowledgeBase(str(tmp_path / "kb.db"))
+    kb.add_entry("hello world")
+    with caplog.at_level(logging.WARNING):
+        results = await kb.search(query="hello")
+    assert len(results) == 1
+    assert "min_score" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_search_min_score_mock_default_no_warning(tmp_path, caplog):
+    """search(min_score=0.3) — the mock default — should not warn."""
+    kb = KnowledgeBase(str(tmp_path / "kb.db"))
+    kb.add_entry("hello world")
+    with caplog.at_level(logging.WARNING):
+        results = await kb.search(query="hello", min_score=0.3)
+    assert len(results) == 1
+    assert "min_score" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_search_min_score_non_default_warns(tmp_path, caplog):
+    """search(min_score=0.5) — a non-default value — should warn once."""
+    kb = KnowledgeBase(str(tmp_path / "kb.db"))
+    kb.add_entry("hello world")
+    with caplog.at_level(logging.WARNING):
+        await kb.search(query="hello", min_score=0.5)
+    assert "min_score=0.5" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_search_negative_max_results_raises(tmp_path):
+    """search(max_results=-1) should raise ValueError (caller bug)."""
+    kb = KnowledgeBase(str(tmp_path / "kb.db"))
+    kb.add_entry("hello world")
+    with pytest.raises(ValueError, match="max_results must be non-negative"):
+        await kb.search(query="hello", max_results=-1)

--- a/tests/integration/seal/test_knowledge_base.py
+++ b/tests/integration/seal/test_knowledge_base.py
@@ -188,14 +188,14 @@ async def test_search_min_score_none_no_warning(tmp_path, caplog):
 
 
 @pytest.mark.asyncio
-async def test_search_min_score_mock_default_no_warning(tmp_path, caplog):
-    """search(min_score=0.3) — the mock default — should not warn."""
+async def test_search_min_score_mock_default_warns(tmp_path, caplog):
+    """search(min_score=0.3) — even the mock default — should warn."""
     kb = KnowledgeBase(str(tmp_path / "kb.db"))
     kb.add_entry("hello world")
     with caplog.at_level(logging.WARNING):
         results = await kb.search(query="hello", min_score=0.3)
     assert len(results) == 1
-    assert "min_score" not in caplog.text
+    assert "min_score=0.3" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -215,3 +215,12 @@ async def test_search_negative_max_results_raises(tmp_path):
     kb.add_entry("hello world")
     with pytest.raises(ValueError, match="max_results must be non-negative"):
         await kb.search(query="hello", max_results=-1)
+
+
+@pytest.mark.asyncio
+async def test_search_max_results_zero_returns_empty(tmp_path):
+    """search(max_results=0) should return an empty list, not raise."""
+    kb = KnowledgeBase(str(tmp_path / "kb.db"))
+    kb.add_entry("hello world")
+    results = await kb.search(query="hello", max_results=0)
+    assert results == []


### PR DESCRIPTION
## What

 calls `await self.knowledge_base.search(query=..., max_results=..., min_score=..., context=...)` but the real `KnowledgeBase` only had `search_entries(query, tags, metadata, limit)` — different method name, different parameter names, and neither method was async so the `await` would raise `TypeError`.

The system only worked because `EnhancedSealSystem` defaults to `MockKnowledgeBase` (which has a `search` method). When someone injects the real `KnowledgeBase`, knowledge retrieval silently fails.

## Changes

- Added `async def search()` method to `KnowledgeBase` that:
  - Accepts the parameters `EnhancedSealSystem` expects: `query`, `max_results`, `min_score`, `context`
  - Delegates to `search_entries` internally
  - Converts `KnowledgeEntry` objects to plain dicts matching what callers expect
  - `min_score` and `context` are accepted for API compatibility but not used by the current substring-matching implementation

## Verification

- `ruff format --check .` ✅
- `ruff check evoseal/integration/seal/knowledge/` ✅
- `pytest tests/unit/seal/test_enhanced_seal_system.py tests/integration/seal/test_knowledge_base.py tests/integration/seal/test_knowledge_base_concurrent.py tests/integration/seal/test_knowledge_aware_strategy.py -q` → 31 passed ✅

## Addresses

TODO.md P1: Knowledge retrieval in the SEAL subsystem is broken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an asynchronous knowledge-base search interface.
  * Search results can be limited by a maximum result count.
  * Results use a consistent format with content, metadata, tags, timestamps, identifiers, and relevance scores.
  * Added compatibility support for optional scoring and context parameters.
  * Added validation for negative result limits and support for returning no results when the limit is zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->