### PR TITLE
fix(integration): report failed DGM/OpenEvolve remote jobs as unsuccessful

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -143,7 +143,7 @@
 ### DGM/OpenEvolve Adapter Issues Found in Whole-Repo Code Review (2026-07-22)
 
 - [ ] **`evoseal/integration/dgm/` + `dgmr/` and `evoseal/integration/oe/` + `openevolve/` look like duplicated/forked adapter implementations that have drifted apart** — needs a decision on which is canonical and whether the other should be removed or reconciled
-- [ ] **DGM/OpenEvolve job runner reports failed jobs as successful** _(exact file:line needs re-verification — flagged by initial review pass, not yet deep-dived)_
+- [x] **DGM/OpenEvolve job runner reports failed jobs as successful** _(done 2026-08-07)_ — both `dgmr/dgm_adapter.py` `_advance_generation()` and `oe/openevolve_adapter.py` `_evolve_remote()` broke out of the poll loop on `status == "failed"` but then unconditionally fetched the result and returned `{"success": True}`. Fixed both to check the final status after the poll and return `success: False` with the error message when the job failed. Added regression tests in `test_dgm_adapter_remote.py` and `test_openevolve_adapter_remote.py`.
 
 ### CLI Issues Found in Whole-Repo Code Review (2026-07-22)
 
@@ -306,7 +306,7 @@
 | Priority | Total | Done | Notes |
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
-| 🟠 P1    | 24    | 18   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix |
+| 🟠 P1    | 24    | 19   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix; DGM/OE job runner failed-status bug fix |
 | 🟡 P2    | 30    | 25   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix; safety-decision orchestration tests; structured improvement units |
 | 🟢 P3    | 24    | 19   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions; how-it-works tutorial; model_fine_tuner key validation; model_fine_tuner GPU availability check |
 | **Total** | **89** | **73** | |

--- a/TODO.md
+++ b/TODO.md
@@ -143,7 +143,7 @@
 ### DGM/OpenEvolve Adapter Issues Found in Whole-Repo Code Review (2026-07-22)
 
 - [ ] **`evoseal/integration/dgm/` + `dgmr/` and `evoseal/integration/oe/` + `openevolve/` look like duplicated/forked adapter implementations that have drifted apart** — needs a decision on which is canonical and whether the other should be removed or reconciled
-- [x] **DGM/OpenEvolve job runner reports failed jobs as successful** _(done 2026-08-07)_ — both `dgmr/dgm_adapter.py` `_advance_generation()` and `oe/openevolve_adapter.py` `_evolve_remote()` broke out of the poll loop on `status == "failed"` but then unconditionally fetched the result and returned `{"success": True}`. Fixed both to check the final status after the poll and return `success: False` with the error message when the job failed. Added regression tests in `test_dgm_adapter_remote.py` and `test_openevolve_adapter_remote.py`.
+- [x] **DGM/OpenEvolve job runner reports failed jobs as successful** _(done 2026-08-07, refined per review feedback)_ — both `dgmr/dgm_adapter.py` `_advance_generation()` and `oe/openevolve_adapter.py` `_evolve_remote()` broke out of the poll loop on `status == "failed"` but then unconditionally fetched the result and returned `{"success": True}`. Fixed both to check the final status after the poll and return `success: False` with the error message when the job failed. Inverted check to `!= "completed"` so any non-terminal state (timeouts, unknown statuses) is also treated as failure. Added regression tests in `test_dgm_adapter_remote.py` and `test_openevolve_adapter_remote.py`.
 
 ### CLI Issues Found in Whole-Repo Code Review (2026-07-22)
 

--- a/evoseal/integration/dgmr/dgm_adapter.py
+++ b/evoseal/integration/dgmr/dgm_adapter.py
@@ -144,7 +144,11 @@ class DGMAdapter(BaseComponentAdapter):
                         status = await sresp.json()
                         if status.get("status") in ("completed", "failed"):
                             break
-                # result
+                # If the job failed, report it as unsuccessful
+                if status.get("status") == "failed":
+                    error_msg = status.get("error", f"Job {job_id} failed")
+                    return {"success": False, "error": error_msg}
+                # result (only fetched for completed jobs)
                 async with session.get(
                     f"{base}/dgm/jobs/{job_id}/result", headers=self._headers()
                 ) as rresp:

--- a/evoseal/integration/dgmr/dgm_adapter.py
+++ b/evoseal/integration/dgmr/dgm_adapter.py
@@ -146,7 +146,7 @@ class DGMAdapter(BaseComponentAdapter):
                             break
                 # If the job failed, report it as unsuccessful
                 if status.get("status") == "failed":
-                    error_msg = status.get("error", f"Job {job_id} failed")
+                    error_msg = status.get("error") or f"Job {job_id} failed"
                     return {"success": False, "error": error_msg}
                 # result (only fetched for completed jobs)
                 async with session.get(

--- a/evoseal/integration/dgmr/dgm_adapter.py
+++ b/evoseal/integration/dgmr/dgm_adapter.py
@@ -144,9 +144,13 @@ class DGMAdapter(BaseComponentAdapter):
                         status = await sresp.json()
                         if status.get("status") in ("completed", "failed"):
                             break
-                # If the job failed, report it as unsuccessful
-                if status.get("status") == "failed":
-                    error_msg = status.get("error") or f"Job {job_id} failed"
+                # If the job didn't complete, report it as unsuccessful
+                # (covers "failed", timeouts, and any future non-terminal states)
+                if status.get("status") != "completed":
+                    error_msg = (
+                        status.get("error")
+                        or f"Job {job_id} ended with status: {status.get('status')}"
+                    )
                     return {"success": False, "error": error_msg}
                 # result (only fetched for completed jobs)
                 async with session.get(

--- a/evoseal/integration/oe/openevolve_adapter.py
+++ b/evoseal/integration/oe/openevolve_adapter.py
@@ -261,7 +261,12 @@ class OpenEvolveAdapter(BaseComponentAdapter):
                         if status.get("status") in ("completed", "failed"):
                             break
 
-                # Fetch result
+                # If the job failed, report it as unsuccessful
+                if status.get("status") == "failed":
+                    error_msg = status.get("error", f"Job {job_id} failed")
+                    return {"success": False, "error": error_msg}
+
+                # Fetch result (only for completed jobs)
                 async with session.get(
                     f"{base_url.rstrip('/')}/openevolve/jobs/{job_id}/result", headers=headers
                 ) as rresp:

--- a/evoseal/integration/oe/openevolve_adapter.py
+++ b/evoseal/integration/oe/openevolve_adapter.py
@@ -263,7 +263,7 @@ class OpenEvolveAdapter(BaseComponentAdapter):
 
                 # If the job failed, report it as unsuccessful
                 if status.get("status") == "failed":
-                    error_msg = status.get("error", f"Job {job_id} failed")
+                    error_msg = status.get("error") or f"Job {job_id} failed"
                     return {"success": False, "error": error_msg}
 
                 # Fetch result (only for completed jobs)

--- a/evoseal/integration/oe/openevolve_adapter.py
+++ b/evoseal/integration/oe/openevolve_adapter.py
@@ -261,9 +261,13 @@ class OpenEvolveAdapter(BaseComponentAdapter):
                         if status.get("status") in ("completed", "failed"):
                             break
 
-                # If the job failed, report it as unsuccessful
-                if status.get("status") == "failed":
-                    error_msg = status.get("error") or f"Job {job_id} failed"
+                # If the job didn't complete, report it as unsuccessful
+                # (covers "failed", timeouts, and any future non-terminal states)
+                if status.get("status") != "completed":
+                    error_msg = (
+                        status.get("error")
+                        or f"Job {job_id} ended with status: {status.get('status')}"
+                    )
                     return {"success": False, "error": error_msg}
 
                 # Fetch result (only for completed jobs)

--- a/tests/unit/test_dgm_adapter_remote.py
+++ b/tests/unit/test_dgm_adapter_remote.py
@@ -169,3 +169,62 @@ async def test_dgm_advance_generation_remote_failed(monkeypatch):
     assert "evaluation crashed" in res.error
 
     await adapter.stop()
+
+
+class _FakeSessionJobFailedNullError:
+    """Fake session where the job fails with a null error value."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, json=None, headers=None):
+        if url.endswith("/dgm/jobs/advance"):
+            return _FakeResponse(200, {"job_id": "job-failed-null-1"})
+        return _FakeResponse(404, {"error": "not found"})
+
+    def get(self, url, headers=None):
+        if "/dgm/jobs/" in url and url.endswith("/status"):
+            return _FakeResponse(200, {"status": "failed", "error": None})
+        return _FakeResponse(404, {"error": "not found"})
+
+
+@pytest.mark.asyncio
+async def test_dgm_advance_generation_remote_failed_null_error(monkeypatch):
+    """A failed job with error=null must surface the generic fallback, not None."""
+    from evoseal.integration.dgmr import dgm_adapter as dgm_mod
+
+    class _FakeTimeout:
+        def __init__(self, total=None):
+            self.total = total
+
+    monkeypatch.setattr(
+        dgm_mod,
+        "aiohttp",
+        types.SimpleNamespace(
+            ClientSession=_FakeSessionJobFailedNullError, ClientTimeout=_FakeTimeout
+        ),
+        raising=False,
+    )
+
+    adapter = create_dgm_adapter(
+        enabled=True,
+        timeout=10,
+        config={"remote": {"base_url": "http://localhost:9999"}},
+    )
+
+    assert await adapter.initialize()
+    assert await adapter.start()
+
+    res = await adapter.execute("advance_generation", data={})
+    assert not res.success, "Failed job should report success=False"
+    assert res.error is not None
+    assert res.error != ""
+    assert "job-failed-null-1" in res.error
+
+    await adapter.stop()

--- a/tests/unit/test_dgm_adapter_remote.py
+++ b/tests/unit/test_dgm_adapter_remote.py
@@ -114,3 +114,58 @@ async def test_dgm_update_archive_remote(monkeypatch):
     assert res.data["result"]["ok"] is True
 
     await adapter.stop()
+
+
+class _FakeSessionJobFailed:
+    """Fake session where the job fails after submission."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, json=None, headers=None):
+        if url.endswith("/dgm/jobs/advance"):
+            return _FakeResponse(200, {"job_id": "job-failed-1"})
+        return _FakeResponse(404, {"error": "not found"})
+
+    def get(self, url, headers=None):
+        if "/dgm/jobs/" in url and url.endswith("/status"):
+            return _FakeResponse(200, {"status": "failed", "error": "evaluation crashed"})
+        return _FakeResponse(404, {"error": "not found"})
+
+
+@pytest.mark.asyncio
+async def test_dgm_advance_generation_remote_failed(monkeypatch):
+    """A failed DGM job must report success=False, not silently succeed."""
+    from evoseal.integration.dgmr import dgm_adapter as dgm_mod
+
+    class _FakeTimeout:
+        def __init__(self, total=None):
+            self.total = total
+
+    monkeypatch.setattr(
+        dgm_mod,
+        "aiohttp",
+        types.SimpleNamespace(ClientSession=_FakeSessionJobFailed, ClientTimeout=_FakeTimeout),
+        raising=False,
+    )
+
+    adapter = create_dgm_adapter(
+        enabled=True,
+        timeout=10,
+        config={"remote": {"base_url": "http://localhost:9999"}},
+    )
+
+    assert await adapter.initialize()
+    assert await adapter.start()
+
+    res = await adapter.execute("advance_generation", data={})
+    assert not res.success, "Failed job should report success=False"
+    assert "evaluation crashed" in res.error
+
+    await adapter.stop()

--- a/tests/unit/test_openevolve_adapter_remote.py
+++ b/tests/unit/test_openevolve_adapter_remote.py
@@ -132,3 +132,62 @@ async def test_openevolve_evolve_remote_failed(monkeypatch):
     assert "evolution crashed" in res.error
 
     await adapter.stop()
+
+
+class _FakeSessionJobFailedNullError:
+    """Fake session where the job fails with a null error value."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, json=None, headers=None):
+        if url.endswith("/openevolve/jobs/evolve"):
+            return _FakeResponse(200, {"job_id": "job-oe-failed-null-1"})
+        return _FakeResponse(404, {"error": "not found"})
+
+    def get(self, url, headers=None):
+        if "/openevolve/jobs/" in url and url.endswith("/status"):
+            return _FakeResponse(200, {"status": "failed", "error": None})
+        return _FakeResponse(404, {"error": "not found"})
+
+
+@pytest.mark.asyncio
+async def test_openevolve_evolve_remote_failed_null_error(monkeypatch):
+    """A failed job with error=null must surface the generic fallback, not None."""
+    from evoseal.integration.oe import openevolve_adapter as oe_mod
+
+    class _FakeTimeout:
+        def __init__(self, total=None):
+            self.total = total
+
+    monkeypatch.setattr(
+        oe_mod,
+        "aiohttp",
+        types.SimpleNamespace(
+            ClientSession=_FakeSessionJobFailedNullError, ClientTimeout=_FakeTimeout
+        ),
+        raising=False,
+    )
+
+    adapter = create_openevolve_adapter(
+        enabled=True,
+        timeout=10,
+        config={"mode": "remote", "remote": {"base_url": "http://localhost:9999"}},
+    )
+
+    assert await adapter.initialize()
+    assert await adapter.start()
+
+    res = await adapter.execute("evolve", data={"job": {"foo": "bar"}})
+    assert not res.success, "Failed job should report success=False"
+    assert res.error is not None
+    assert res.error != ""
+    assert "job-oe-failed-null-1" in res.error
+
+    await adapter.stop()

--- a/tests/unit/test_openevolve_adapter_remote.py
+++ b/tests/unit/test_openevolve_adapter_remote.py
@@ -77,3 +77,58 @@ async def test_openevolve_evolve_remote(monkeypatch):
     assert res.data["result"]["result"]["program_id"] == "p1"
 
     await adapter.stop()
+
+
+class _FakeSessionJobFailed:
+    """Fake session where the job fails after submission."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, json=None, headers=None):
+        if url.endswith("/openevolve/jobs/evolve"):
+            return _FakeResponse(200, {"job_id": "job-oe-failed-1"})
+        return _FakeResponse(404, {"error": "not found"})
+
+    def get(self, url, headers=None):
+        if "/openevolve/jobs/" in url and url.endswith("/status"):
+            return _FakeResponse(200, {"status": "failed", "error": "evolution crashed"})
+        return _FakeResponse(404, {"error": "not found"})
+
+
+@pytest.mark.asyncio
+async def test_openevolve_evolve_remote_failed(monkeypatch):
+    """A failed OpenEvolve job must report success=False, not silently succeed."""
+    from evoseal.integration.oe import openevolve_adapter as oe_mod
+
+    class _FakeTimeout:
+        def __init__(self, total=None):
+            self.total = total
+
+    monkeypatch.setattr(
+        oe_mod,
+        "aiohttp",
+        types.SimpleNamespace(ClientSession=_FakeSessionJobFailed, ClientTimeout=_FakeTimeout),
+        raising=False,
+    )
+
+    adapter = create_openevolve_adapter(
+        enabled=True,
+        timeout=10,
+        config={"mode": "remote", "remote": {"base_url": "http://localhost:9999"}},
+    )
+
+    assert await adapter.initialize()
+    assert await adapter.start()
+
+    res = await adapter.execute("evolve", data={"job": {"foo": "bar"}})
+    assert not res.success, "Failed job should report success=False"
+    assert "evolution crashed" in res.error
+
+    await adapter.stop()


### PR DESCRIPTION
## What

Both `dgmr/dgm_adapter.py` and `oe/openevolve_adapter.py` had a bug in their remote job polling: when the remote service reported a job as `"failed"`, the adapters broke out of the poll loop but then unconditionally fetched the result and returned `success=True`. A job that crashed or timed out on the remote service was silently treated as a success by the adapter layer.

## Fix

Both adapters now check the final status **after** the poll loop exits. When `status == "failed"`, they return `success=False` with the error message from the remote service. The result endpoint is only fetched for completed jobs.

## Files changed

- `evoseal/integration/dgmr/dgm_adapter.py` — added failed-status check in `_advance_generation()`
- `evoseal/integration/oe/openevolve_adapter.py` — added failed-status check in `_evolve_remote()`
- `tests/unit/test_dgm_adapter_remote.py` — added `test_dgm_advance_generation_remote_failed`
- `tests/unit/test_openevolve_adapter_remote.py` — added `test_openevolve_evolve_remote_failed`
- `TODO.md` — checked off "DGM/OpenEvolve job runner reports failed jobs as successful"

## Verification

```
$ ruff format --check .     → 414 files already formatted
$ ruff check evoseal/integration/dgmr/ evoseal/integration/oe/ tests/unit/test_dgm_adapter_remote.py tests/unit/test_openevolve_adapter_remote.py → All checks passed!
$ pytest tests/unit/test_dgm_adapter_remote.py tests/unit/test_openevolve_adapter_remote.py -q → 5 passed
```

Addresses TODO.md P1 item: "DGM/OpenEvolve job runner reports failed jobs as successful"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Remote DGM and OpenEvolve jobs now report unsuccessful results immediately when a job fails.
  - Failure responses include the server-provided error message, with a fallback message when none is available.
  - Results are only retrieved after jobs complete successfully.

- **Tests**
  - Added regression coverage for failed remote jobs and error-message propagation across both integrations.

- **Documentation**
  - Updated completion tracking to reflect the resolved remote job failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->