### PR TITLE
chore(spike): PBT feasibility spike — verdict VALIDATED

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -307,10 +307,10 @@
 | Priority | Total | Done | Notes |
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
-| 🟠 P1    | 24    | 19   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix; DGM/OE job runner failed-status bug fix |
-| 🟡 P2    | 30    | 25   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix; safety-decision orchestration tests; structured improvement units |
-| 🟢 P3    | 26    | 21   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions; how-it-works tutorial; model_fine_tuner key validation; model_fine_tuner GPU availability check; PBT exploration ADR; PBT feasibility spike |
-| **Total** | **91** | **76** | |
+| 🟠 P1    | 24    | 18   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix; DGM/OE job runner failed-status bug fix |
+| 🟡 P2    | 33    | 29   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix; safety-decision orchestration tests; structured improvement units |
+| 🟢 P3    | 26    | 22   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions; how-it-works tutorial; model_fine_tuner key validation; model_fine_tuner GPU availability check; PBT exploration ADR; PBT feasibility spike |
+| **Total** | **94** | **80** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -308,9 +308,9 @@
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 18   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix; DGM/OE job runner failed-status bug fix |
-| 🟡 P2    | 33    | 29   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix; safety-decision orchestration tests; structured improvement units |
+| 🟡 P2    | 35    | 30   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix; safety-decision orchestration tests; structured improvement units |
 | 🟢 P3    | 26    | 22   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions; how-it-works tutorial; model_fine_tuner key validation; model_fine_tuner GPU availability check; PBT exploration ADR; PBT feasibility spike |
-| **Total** | **94** | **80** | |
+| **Total** | **96** | **81** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/TODO.md
+++ b/TODO.md
@@ -295,7 +295,7 @@
   - README mentions Ollama integration — verify it works end-to-end
 - [x] **Explore population-based training (PBT) as alternative to MAP-Elites** _(done 2026-08-07)_ — ADR 0005 evaluates PBT as a complement (not replacement) for MAP-Elites in hyperparameter tuning. Conclusion: PBT and MAP-Elites solve different problems (hyperparameters vs. code variants); PBT is worth exploring but prerequisites (local model support, sensitivity analysis) aren't in place yet. Recommended next step is a feasibility spike with parallel runs, not a full implementation. Document at `docs/adr/0005-population-based-training.md`
 - [ ] **Document EVOSEAL's hyperparameter space** _(follow-up from ADR 0005 §6)_ — enumerate all tuneable pipeline parameters (mutation rate, selection pressure, temperature, etc.) and their current values/ranges; prerequisite for PBT feasibility spike
-- [ ] **Run PBT feasibility spike** _(follow-up from ADR 0005 §6)_ — 3-5 parallel pipeline runs with manually varied hyperparameters for 10 generations; measure outcome variance; decide if the spread justifies adaptive tuning (use `spike` skill)
+- [x] **Run PBT feasibility spike** _(done 2026-08-08)_ — `spikes/pbt-feasibility/`: 5 configs × 5 seeds × 10 generations on synthetic fitness landscape. Best-fitness spread 22.9% (>10% ADR 0005 threshold). Verdict: VALIDATED. Next: PBT design doc.
 - [ ] **Human-in-the-loop feedback interface**
   - Allow a developer to approve/reject self-modifications via the dashboard
   - Track acceptance rate as a meta-metric
@@ -309,8 +309,8 @@
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
 | 🟠 P1    | 24    | 19   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix; DGM/OE job runner failed-status bug fix |
 | 🟡 P2    | 30    | 25   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix; safety-decision orchestration tests; structured improvement units |
-| 🟢 P3    | 26    | 20   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions; how-it-works tutorial; model_fine_tuner key validation; model_fine_tuner GPU availability check; PBT exploration ADR |
-| **Total** | **91** | **75** | |
+| 🟢 P3    | 26    | 21   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions; how-it-works tutorial; model_fine_tuner key validation; model_fine_tuner GPU availability check; PBT exploration ADR; PBT feasibility spike |
+| **Total** | **91** | **76** | |
 
 > Update this table as you complete items. Recommended flow: P0 → P1 → P2 → P3.
 >

--- a/spikes/pbt-feasibility/README.md
+++ b/spikes/pbt-feasibility/README.md
@@ -39,11 +39,19 @@ hyperparameter optimization strategy.
 - Average fitness: 0.012 (2.3%) — below threshold (expected: population average is less sensitive)
 - Improvement spread: 0.168
 
-## Verdict: VALIDATED
+## Verdict: VALIDATED (with caveats)
 
 Hyperparameter variance produces meaningful outcome differences in the
 pipeline's selection/mutation mechanics. The 22.9% best-fitness spread across
 configs is more than double the 10% threshold.
+
+**Important:** This verdict is driven entirely by the best-fitness metric
+(max-order statistic), not the population average (2.3% — below threshold).
+With only n=5 seeds per config, best fitness is inherently noisier than the
+mean and no significance test (t-test / confidence interval) was run against
+the per-config standard deviations before drawing this conclusion. Treat the
+VALIDATED verdict as directional evidence that hyperparameters matter, not as
+statistically robust proof.
 
 **Key finding:** The "exploratory" config (small tournament, no elitism, high
 mutation) achieved 24.7% higher best fitness than "exploitative" — but with
@@ -60,6 +68,14 @@ designed to navigate adaptively.
 3. EVOSEAL's real fitness function involves code correctness, efficiency, and
    readability — multi-dimensional in a way that may amplify or dampen
    hyperparameter sensitivity.
+4. **Statistical confidence:** The verdict uses an ``or`` gate (either
+   best-fitness or average-fitness spread exceeding 10%). Best fitness is a
+   max-order statistic — with n=5 seeds/config, it has higher sampling
+   variance than the population mean. The average-fitness spread (2.3%) was
+   well below threshold; only best fitness (22.9%) crossed it. A stricter
+   analysis would run a significance test (e.g. Welch's t-test or bootstrap
+   CI) against the per-config standard deviations before concluding the spread
+   is signal rather than noise.
 
 ## Recommendation
 

--- a/spikes/pbt-feasibility/README.md
+++ b/spikes/pbt-feasibility/README.md
@@ -28,11 +28,11 @@ hyperparameter optimization strategy.
 
 | Config | Tournament | Elitism | Mut Rate | Mut Mag | Final Best | Improvement |
 |--------|-----------|---------|----------|---------|------------|-------------|
-| baseline | 3 | 1 | 0.10 | 0.05 | 0.708 ± 0.039 | +0.025 |
+| baseline | 3 | 1 | 0.10 | 0.05 | 0.686 ± 0.021 | +0.003 |
 | exploratory | 2 | 0 | 0.30 | 0.15 | 0.848 ± 0.066 | +0.165 |
-| exploitative | 7 | 3 | 0.05 | 0.02 | 0.680 ± 0.022 | −0.003 |
-| balanced | 4 | 2 | 0.15 | 0.08 | 0.744 ± 0.058 | +0.061 |
-| conservative | 3 | 5 | 0.05 | 0.03 | 0.686 ± 0.030 | +0.003 |
+| exploitative | 7 | 3 | 0.05 | 0.02 | 0.683 ± 0.023 | +0.000 |
+| balanced | 4 | 2 | 0.15 | 0.08 | 0.703 ± 0.023 | +0.020 |
+| conservative | 3 | 5 | 0.05 | 0.03 | 0.683 ± 0.023 | +0.000 |
 
 **Cross-config spread:**
 - Best fitness: 0.168 (**22.9%**) — exceeds 10% threshold ✓
@@ -54,8 +54,8 @@ VALIDATED verdict as directional evidence that hyperparameters matter, not as
 statistically robust proof.
 
 **Key finding:** The "exploratory" config (small tournament, no elitism, high
-mutation) achieved 24.7% higher best fitness than "exploitative" — but with
-2.5× more variance. This is exactly the explore-exploit tradeoff that PBT is
+mutation) achieved 24.2% higher best fitness than "exploitative" — but with
+2.9× more variance. This is exactly the explore-exploit tradeoff that PBT is
 designed to navigate adaptively.
 
 ### Caveats

--- a/spikes/pbt-feasibility/README.md
+++ b/spikes/pbt-feasibility/README.md
@@ -76,6 +76,15 @@ designed to navigate adaptively.
    analysis would run a significance test (e.g. Welch's t-test or bootstrap
    CI) against the per-config standard deviations before concluding the spread
    is signal rather than noise.
+5. **Near-identical non-exploratory configs:** The "exploitative" and
+   "conservative" configs produced bit-for-bit identical
+   ``final_best_mean`` / ``final_best_std`` / ``improvement_mean`` /
+   ``improvement_std`` values. This is expected (same seeds 42–46 per-config,
+   high elitism protecting the initial best individual from mutation), but it
+   means the 22.9% headline spread is driven almost entirely by the single
+   "exploratory" outlier versus three configs clustered near-identically. The
+   effective spread is "exploratory vs. the rest", not a gradual gradient
+   across the hyperparameter space.
 
 ## Recommendation
 

--- a/spikes/pbt-feasibility/README.md
+++ b/spikes/pbt-feasibility/README.md
@@ -1,0 +1,81 @@
+# PBT Feasibility Spike
+
+## Question
+
+Does varying EVOSEAL's pipeline hyperparameters (tournament size, elitism,
+mutation rate/magnitude) produce meaningful outcome differences across parallel
+runs? If so, Population-Based Training (PBT) is justified as a complementary
+hyperparameter optimization strategy.
+
+## Threshold (ADR 0005 §6)
+
+> If the variance is meaningful (>10% fitness spread), PBT is justified. If
+> not, the hyperparameter space may be too narrow to warrant the overhead.
+
+## Method
+
+- **Synthetic population** of 50 individuals with 3-dimensional fitness scores
+  drawn from N(0.5, 0.15), clamped to [0, 1].
+- **5 hyperparameter configs** tested (baseline, exploratory, exploitative,
+  balanced, conservative) — each with 5 random seeds.
+- **10 generations** of tournament selection + Gaussian perturbation per run.
+- **Metrics tracked:** best fitness, average fitness, diversity (std dev), and
+  improvement (delta from gen 0 to gen 10).
+- **Cross-config spread:** max(best_fitness_mean) − min(best_fitness_mean)
+  across configs, expressed as % of overall mean.
+
+## Results
+
+| Config | Tournament | Elitism | Mut Rate | Mut Mag | Final Best | Improvement |
+|--------|-----------|---------|----------|---------|------------|-------------|
+| baseline | 3 | 1 | 0.10 | 0.05 | 0.708 ± 0.039 | +0.025 |
+| exploratory | 2 | 0 | 0.30 | 0.15 | 0.848 ± 0.066 | +0.165 |
+| exploitative | 7 | 3 | 0.05 | 0.02 | 0.680 ± 0.022 | −0.003 |
+| balanced | 4 | 2 | 0.15 | 0.08 | 0.744 ± 0.058 | +0.061 |
+| conservative | 3 | 5 | 0.05 | 0.03 | 0.686 ± 0.030 | +0.003 |
+
+**Cross-config spread:**
+- Best fitness: 0.168 (**22.9%**) — exceeds 10% threshold ✓
+- Average fitness: 0.012 (2.3%) — below threshold (expected: population average is less sensitive)
+- Improvement spread: 0.168
+
+## Verdict: VALIDATED
+
+Hyperparameter variance produces meaningful outcome differences in the
+pipeline's selection/mutation mechanics. The 22.9% best-fitness spread across
+configs is more than double the 10% threshold.
+
+**Key finding:** The "exploratory" config (small tournament, no elitism, high
+mutation) achieved 24.7% higher best fitness than "exploitative" — but with
+2.5× more variance. This is exactly the explore-exploit tradeoff that PBT is
+designed to navigate adaptively.
+
+### Caveats
+
+1. This spike uses synthetic fitness landscapes, not real LLM-generated code
+   variants. Real fitness landscapes may be more or less sensitive to
+   hyperparameter changes.
+2. The spike tests selection + mutation only. It does not exercise the full
+   pipeline (generation, evaluation, self-modification).
+3. EVOSEAL's real fitness function involves code correctness, efficiency, and
+   readability — multi-dimensional in a way that may amplify or dampen
+   hyperparameter sensitivity.
+
+## Recommendation
+
+Proceed to a PBT implementation design doc with:
+- Concrete integration points (where PBT hooks into the evolution loop)
+- Cost model (N× parallel runs vs. convergence speedup)
+- Checkpoint strategy (how to save/restore PBT population state)
+
+### Next steps (if proceeding)
+1. Run a second spike with real LLM calls (requires API keys) to validate
+   synthetic-fitness transferability.
+2. Design doc covering PBT integration with `ContinuousEvolutionService`.
+3. Prototype PBT as a thin wrapper around the existing `EvolutionPipeline`.
+
+## Files
+
+- `spike.py` — the spike script (standalone, no external deps)
+- `results.json` — raw numerical results
+- `README.md` — this file

--- a/spikes/pbt-feasibility/results.json
+++ b/spikes/pbt-feasibility/results.json
@@ -1,0 +1,87 @@
+{
+  "cross_config": {
+    "best_spread": 0.1680013525466817,
+    "avg_spread": 0.011974028705567075,
+    "improvement_spread": 0.1680013525466817,
+    "best_relative_spread_pct": 22.916763679637437,
+    "avg_relative_spread_pct": 2.3427037337250862
+  },
+  "threshold": 10.0,
+  "config_stats": {
+    "baseline": {
+      "final_best_mean": 0.7077416479335308,
+      "final_best_std": 0.03899223141305548,
+      "final_avg_mean": 0.5088570682762047,
+      "final_avg_std": 0.005511309285575978,
+      "improvement_mean": 0.024688083342247414,
+      "improvement_std": 0.02433857489221635,
+      "final_diversity_mean": 0.0942276902863182,
+      "config": {
+        "tournament_size": 3,
+        "elitism": 1,
+        "mutation_rate": 0.1,
+        "mutation_mag": 0.05
+      }
+    },
+    "exploratory": {
+      "final_best_mean": 0.8481989163921116,
+      "final_best_std": 0.06614952913584142,
+      "final_avg_mean": 0.5185948855791074,
+      "final_avg_std": 0.02194200840623887,
+      "improvement_mean": 0.1651453518008283,
+      "improvement_std": 0.04966375870251193,
+      "final_diversity_mean": 0.14559941343965566,
+      "config": {
+        "tournament_size": 2,
+        "elitism": 0,
+        "mutation_rate": 0.3,
+        "mutation_mag": 0.15
+      }
+    },
+    "exploitative": {
+      "final_best_mean": 0.68019756384543,
+      "final_best_std": 0.02192106188921366,
+      "final_avg_mean": 0.5072431130599354,
+      "final_avg_std": 0.005211584881918314,
+      "improvement_mean": -0.0028560007458534155,
+      "improvement_std": 0.007487586457496208,
+      "final_diversity_mean": 0.08585230099748709,
+      "config": {
+        "tournament_size": 7,
+        "elitism": 3,
+        "mutation_rate": 0.05,
+        "mutation_mag": 0.02
+      }
+    },
+    "balanced": {
+      "final_best_mean": 0.7435322168544884,
+      "final_best_std": 0.05829689510200298,
+      "final_avg_mean": 0.5142843711164952,
+      "final_avg_std": 0.011560604809098936,
+      "improvement_mean": 0.060478652263205125,
+      "improvement_std": 0.03844175044789527,
+      "final_diversity_mean": 0.09842369492926512,
+      "config": {
+        "tournament_size": 4,
+        "elitism": 2,
+        "mutation_rate": 0.15,
+        "mutation_mag": 0.08
+      }
+    },
+    "conservative": {
+      "final_best_mean": 0.6857981935351074,
+      "final_best_std": 0.03017831363951221,
+      "final_avg_mean": 0.5066208568735403,
+      "final_avg_std": 0.005834518416640367,
+      "improvement_mean": 0.002744628943824057,
+      "improvement_std": 0.007995368954835816,
+      "final_diversity_mean": 0.08685445383460572,
+      "config": {
+        "tournament_size": 3,
+        "elitism": 5,
+        "mutation_rate": 0.05,
+        "mutation_mag": 0.03
+      }
+    }
+  }
+}

--- a/spikes/pbt-feasibility/results.json
+++ b/spikes/pbt-feasibility/results.json
@@ -1,21 +1,21 @@
 {
   "cross_config": {
-    "best_spread": 0.1680013525466817,
-    "avg_spread": 0.011974028705567075,
-    "improvement_spread": 0.1680013525466817,
-    "best_relative_spread_pct": 22.916763679637437,
-    "avg_relative_spread_pct": 2.3427037337250862
+    "best_spread": 0.16514535180082834,
+    "avg_spread": 0.011606484837906383,
+    "improvement_spread": 0.1651453518008283,
+    "best_relative_spread_pct": 22.91945104750708,
+    "avg_relative_spread_pct": 2.276495475001551
   },
   "threshold": 10.0,
   "config_stats": {
     "baseline": {
-      "final_best_mean": 0.7077416479335308,
-      "final_best_std": 0.03899223141305548,
-      "final_avg_mean": 0.5088570682762047,
-      "final_avg_std": 0.005511309285575978,
-      "improvement_mean": 0.024688083342247414,
-      "improvement_std": 0.02433857489221635,
-      "final_diversity_mean": 0.0942276902863182,
+      "final_best_mean": 0.685804075891288,
+      "final_best_std": 0.021335015617707242,
+      "final_avg_mean": 0.506988400741201,
+      "final_avg_std": 0.006024486931797842,
+      "improvement_mean": 0.0027505113000046546,
+      "improvement_std": 0.006150330239691725,
+      "final_diversity_mean": 0.08740312246849143,
       "config": {
         "tournament_size": 3,
         "elitism": 1,
@@ -39,13 +39,13 @@
       }
     },
     "exploitative": {
-      "final_best_mean": 0.68019756384543,
-      "final_best_std": 0.02192106188921366,
-      "final_avg_mean": 0.5072431130599354,
-      "final_avg_std": 0.005211584881918314,
-      "improvement_mean": -0.0028560007458534155,
-      "improvement_std": 0.007487586457496208,
-      "final_diversity_mean": 0.08585230099748709,
+      "final_best_mean": 0.6830535645912833,
+      "final_best_std": 0.022677162666817113,
+      "final_avg_mean": 0.5070149382624282,
+      "final_avg_std": 0.004291519078884196,
+      "improvement_mean": 0.0,
+      "improvement_std": 0.0,
+      "final_diversity_mean": 0.08456140046126104,
       "config": {
         "tournament_size": 7,
         "elitism": 3,
@@ -54,13 +54,13 @@
       }
     },
     "balanced": {
-      "final_best_mean": 0.7435322168544884,
-      "final_best_std": 0.05829689510200298,
-      "final_avg_mean": 0.5142843711164952,
-      "final_avg_std": 0.011560604809098936,
-      "improvement_mean": 0.060478652263205125,
-      "improvement_std": 0.03844175044789527,
-      "final_diversity_mean": 0.09842369492926512,
+      "final_best_mean": 0.7026234575040893,
+      "final_best_std": 0.023077991464650272,
+      "final_avg_mean": 0.5085014669878126,
+      "final_avg_std": 0.00718737086618944,
+      "improvement_mean": 0.01956989291280593,
+      "improvement_std": 0.01381761760929656,
+      "final_diversity_mean": 0.09746178499028288,
       "config": {
         "tournament_size": 4,
         "elitism": 2,
@@ -69,13 +69,13 @@
       }
     },
     "conservative": {
-      "final_best_mean": 0.6857981935351074,
-      "final_best_std": 0.03017831363951221,
-      "final_avg_mean": 0.5066208568735403,
-      "final_avg_std": 0.005834518416640367,
-      "improvement_mean": 0.002744628943824057,
-      "improvement_std": 0.007995368954835816,
-      "final_diversity_mean": 0.08685445383460572,
+      "final_best_mean": 0.6830535645912833,
+      "final_best_std": 0.022677162666817113,
+      "final_avg_mean": 0.5081003761120968,
+      "final_avg_std": 0.005309897675491963,
+      "improvement_mean": 0.0,
+      "improvement_std": 0.0,
+      "final_diversity_mean": 0.0860250683729827,
       "config": {
         "tournament_size": 3,
         "elitism": 5,

--- a/spikes/pbt-feasibility/spike.py
+++ b/spikes/pbt-feasibility/spike.py
@@ -86,7 +86,9 @@ SEED_BASE = 42
 
 
 # ---------------------------------------------------------------------------
-# Core mechanics (mirrors evoseal/core/selection.py logic, but deterministic)
+# Core mechanics (selection mirrors evoseal/core/selection.py logic, but
+# deterministic via explicit rng; mutation loop is spike-only — production
+# uses self_improve_step which has different semantics).
 # ---------------------------------------------------------------------------
 
 
@@ -178,18 +180,26 @@ def run_generation(
     config: dict[str, Any],
     rng: random.Random,
 ) -> list[Individual]:
-    """One generation: select → mutate → return next generation."""
-    # Selection
+    """One generation: select → mutate → return next generation.
+
+    Elites survive unchanged — only non-elite selected individuals are
+    mutated.  This preserves the standard elitism guarantee that the best
+    fitness is non-decreasing across generations.
+    """
+    elitism = config["elitism"]
+    # Selection (elites are the first ``elitism`` entries in the returned list)
     selected = tournament_select(
         population,
         n=len(population),
         tournament_size=config["tournament_size"],
-        elitism=config["elitism"],
+        elitism=elitism,
         rng=rng,
     )
-    # Mutation
-    next_gen = [
-        mutate(ind, config["mutation_rate"], config["mutation_mag"], rng) for ind in selected
+    # Elites pass through unchanged; the rest are mutated.
+    elites = selected[:elitism]
+    rest = selected[elitism:]
+    next_gen = elites + [
+        mutate(ind, config["mutation_rate"], config["mutation_mag"], rng) for ind in rest
     ]
     return next_gen
 

--- a/spikes/pbt-feasibility/spike.py
+++ b/spikes/pbt-feasibility/spike.py
@@ -19,10 +19,8 @@ Usage:
 from __future__ import annotations
 
 import json
-import math
 import random
 import statistics
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any

--- a/spikes/pbt-feasibility/spike.py
+++ b/spikes/pbt-feasibility/spike.py
@@ -149,6 +149,11 @@ def tournament_select(
 
     # Fill if needed (guard against empty pool — e.g. elitism=0 with
     # an empty starting population, or n=0 reuse elsewhere).
+    # Duplicates are possible here (same Individual reference appended
+    # multiple times).  This is benign because mutate() always creates a
+    # new Individual object for non-elites, so the next generation still
+    # has distinct objects.  With the current configs (POPULATION_SIZE=50,
+    # elitism<=5) the fill path is extremely unlikely to trigger.
     if selected:
         while len(selected) < n:
             selected.append(rng.choice(selected))
@@ -185,7 +190,8 @@ def run_generation(
     fitness is non-decreasing across generations.
     """
     elitism = config["elitism"]
-    # Selection (elites are the first ``elitism`` entries in the returned list)
+    # Selection — relies on tournament_select returning elites as the
+    # first ``elitism`` entries (preserved unmutated below).
     selected = tournament_select(
         population,
         n=len(population),

--- a/spikes/pbt-feasibility/spike.py
+++ b/spikes/pbt-feasibility/spike.py
@@ -90,9 +90,16 @@ SEED_BASE = 42
 # ---------------------------------------------------------------------------
 
 
-@dataclass
+@dataclass(eq=False)
 class Individual:
-    """Synthetic individual with multi-dimensional fitness."""
+    """Synthetic individual with multi-dimensional fitness.
+
+    eq=False so that ``in`` and ``.remove()`` compare by object identity,
+    not by value.  Two distinct individuals can share the same ``id`` and
+    ``fitness`` (e.g. via the fill-when-undersized fallback in
+    ``tournament_select``); value-based equality would silently collapse
+    them and corrupt the selection pool.
+    """
 
     id: int
     fitness: list[float]  # per-dimension fitness scores
@@ -140,9 +147,11 @@ def tournament_select(
         selected.append(winner)
         pop.remove(winner)
 
-    # Fill if needed
-    while len(selected) < n:
-        selected.append(rng.choice(selected))
+    # Fill if needed (guard against empty pool — e.g. elitism=0 with
+    # an empty starting population, or n=0 reuse elsewhere).
+    if selected:
+        while len(selected) < n:
+            selected.append(rng.choice(selected))
 
     return selected[:n]
 
@@ -354,6 +363,14 @@ def print_report(results: dict[str, Any]) -> None:
     print()
 
     # Verdict
+    # NOTE: Using ``or`` (either metric crossing threshold) as the VALIDATED
+    # gate.  Best-fitness is a max-order statistic and inherently noisier
+    # across small samples (n=5 seeds/config) than the population average.
+    # A stricter gate would require a significance test (e.g. t-test or CI)
+    # against the per-config std devs before drawing a conclusion.  The
+    # current threshold is intentionally permissive — the spike answers
+    # "is there *any* signal?" rather than "is the signal statistically
+    # robust?"  Treat the VALIDATED verdict as directional, not definitive.
     best_pct = cross["best_relative_spread_pct"]
     avg_pct = cross["avg_relative_spread_pct"]
     exceeds = best_pct > threshold or avg_pct > threshold

--- a/spikes/pbt-feasibility/spike.py
+++ b/spikes/pbt-feasibility/spike.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+PBT Feasibility Spike — measures whether hyperparameter variance produces
+meaningful outcome differences in EVOSEAL's pipeline.
+
+Verdict threshold (from ADR 0005 §6): >10% fitness spread across configs
+justifies PBT; otherwise the hyperparameter space is too narrow.
+
+This spike exercises the selection + perturbation loop with synthetic fitness
+landscapes, varying tournament_size, elitism, and mutation magnitude.  It does
+NOT require API keys or real LLM calls — the question is purely whether the
+pipeline's internal hyperparameters create enough outcome variance to warrant
+adaptive tuning.
+
+Usage:
+    python spikes/pbt-feasibility/spike.py
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+import statistics
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+POPULATION_SIZE = 50
+GENERATIONS = 10
+RUNS_PER_CONFIG = 5  # repetitions with different seeds for each config
+INITIAL_FITNESS_MEAN = 0.5
+INITIAL_FITNESS_STD = 0.15
+FITNESS_DIMENSIONS = 3  # multi-dimensional fitness
+
+# Hyperparameter grid — each dict is one "config"
+CONFIGS: list[dict[str, Any]] = [
+    # Baseline (current defaults)
+    {
+        "name": "baseline",
+        "tournament_size": 3,
+        "elitism": 1,
+        "mutation_rate": 0.1,
+        "mutation_mag": 0.05,
+    },
+    # Small tournament, high mutation — more exploration
+    {
+        "name": "exploratory",
+        "tournament_size": 2,
+        "elitism": 0,
+        "mutation_rate": 0.3,
+        "mutation_mag": 0.15,
+    },
+    # Large tournament, low mutation — more exploitation
+    {
+        "name": "exploitative",
+        "tournament_size": 7,
+        "elitism": 3,
+        "mutation_rate": 0.05,
+        "mutation_mag": 0.02,
+    },
+    # Moderate — balanced
+    {
+        "name": "balanced",
+        "tournament_size": 4,
+        "elitism": 2,
+        "mutation_rate": 0.15,
+        "mutation_mag": 0.08,
+    },
+    # High elitism — conservative
+    {
+        "name": "conservative",
+        "tournament_size": 3,
+        "elitism": 5,
+        "mutation_rate": 0.05,
+        "mutation_mag": 0.03,
+    },
+]
+
+SEED_BASE = 42
+
+
+# ---------------------------------------------------------------------------
+# Core mechanics (mirrors evoseal/core/selection.py logic, but deterministic)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Individual:
+    """Synthetic individual with multi-dimensional fitness."""
+
+    id: int
+    fitness: list[float]  # per-dimension fitness scores
+
+    @property
+    def aggregate_fitness(self) -> float:
+        """Weighted sum of fitness dimensions (equal weights)."""
+        return sum(self.fitness) / len(self.fitness)
+
+
+def generate_population(size: int, rng: random.Random) -> list[Individual]:
+    """Create a synthetic population with normally-distributed fitness."""
+    pop = []
+    for i in range(size):
+        fitness = [
+            max(0.0, min(1.0, rng.gauss(INITIAL_FITNESS_MEAN, INITIAL_FITNESS_STD)))
+            for _ in range(FITNESS_DIMENSIONS)
+        ]
+        pop.append(Individual(id=i, fitness=fitness))
+    return pop
+
+
+def tournament_select(
+    population: list[Individual],
+    n: int,
+    tournament_size: int,
+    elitism: int,
+    rng: random.Random,
+) -> list[Individual]:
+    """Tournament selection with elitism (deterministic via rng)."""
+    selected: list[Individual] = []
+    pop = population[:]
+
+    # Elitism: preserve top-N
+    if elitism > 0:
+        sorted_pop = sorted(pop, key=lambda x: x.aggregate_fitness, reverse=True)
+        elites = sorted_pop[:elitism]
+        selected.extend(elites)
+        pop = [ind for ind in pop if ind not in elites]
+
+    while len(selected) < n and pop:
+        indices = rng.sample(range(len(pop)), min(tournament_size, len(pop)))
+        tournament = [pop[i] for i in indices]
+        winner = max(tournament, key=lambda x: x.aggregate_fitness)
+        selected.append(winner)
+        pop.remove(winner)
+
+    # Fill if needed
+    while len(selected) < n:
+        selected.append(rng.choice(selected))
+
+    return selected[:n]
+
+
+def mutate(
+    individual: Individual,
+    mutation_rate: float,
+    mutation_mag: float,
+    rng: random.Random,
+) -> Individual:
+    """Perturb fitness dimensions to simulate mutation effect."""
+    new_fitness = []
+    for f in individual.fitness:
+        if rng.random() < mutation_rate:
+            delta = rng.gauss(0, mutation_mag)
+            new_fitness.append(max(0.0, min(1.0, f + delta)))
+        else:
+            new_fitness.append(f)
+    return Individual(id=individual.id, fitness=new_fitness)
+
+
+def run_generation(
+    population: list[Individual],
+    config: dict[str, Any],
+    rng: random.Random,
+) -> list[Individual]:
+    """One generation: select → mutate → return next generation."""
+    # Selection
+    selected = tournament_select(
+        population,
+        n=len(population),
+        tournament_size=config["tournament_size"],
+        elitism=config["elitism"],
+        rng=rng,
+    )
+    # Mutation
+    next_gen = [
+        mutate(ind, config["mutation_rate"], config["mutation_mag"], rng) for ind in selected
+    ]
+    return next_gen
+
+
+# ---------------------------------------------------------------------------
+# Spike runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunResult:
+    """Results from one run of one config."""
+
+    config_name: str
+    seed: int
+    best_fitness_per_gen: list[float] = field(default_factory=list)
+    avg_fitness_per_gen: list[float] = field(default_factory=list)
+    diversity_per_gen: list[float] = field(default_factory=list)
+
+    @property
+    def final_best(self) -> float:
+        return self.best_fitness_per_gen[-1] if self.best_fitness_per_gen else 0.0
+
+    @property
+    def final_avg(self) -> float:
+        return self.avg_fitness_per_gen[-1] if self.avg_fitness_per_gen else 0.0
+
+    @property
+    def improvement(self) -> float:
+        """Best fitness improvement over generations."""
+        if len(self.best_fitness_per_gen) < 2:
+            return 0.0
+        return self.best_fitness_per_gen[-1] - self.best_fitness_per_gen[0]
+
+
+def run_single(config: dict[str, Any], seed: int) -> RunResult:
+    """Run one full evolution with a given config and seed."""
+    rng = random.Random(seed)
+    pop = generate_population(POPULATION_SIZE, rng)
+    result = RunResult(config_name=config["name"], seed=seed)
+
+    for gen in range(GENERATIONS):
+        best = max(ind.aggregate_fitness for ind in pop)
+        avg = statistics.mean(ind.aggregate_fitness for ind in pop)
+        # Diversity: std dev of aggregate fitness
+        diversity = statistics.stdev(ind.aggregate_fitness for ind in pop) if len(pop) > 1 else 0.0
+
+        result.best_fitness_per_gen.append(best)
+        result.avg_fitness_per_gen.append(avg)
+        result.diversity_per_gen.append(diversity)
+
+        pop = run_generation(pop, config, rng)
+
+    # Record final generation stats
+    best = max(ind.aggregate_fitness for ind in pop)
+    avg = statistics.mean(ind.aggregate_fitness for ind in pop)
+    diversity = statistics.stdev(ind.aggregate_fitness for ind in pop) if len(pop) > 1 else 0.0
+    result.best_fitness_per_gen.append(best)
+    result.avg_fitness_per_gen.append(avg)
+    result.diversity_per_gen.append(diversity)
+
+    return result
+
+
+def run_spike() -> dict[str, Any]:
+    """Run the full spike across all configs and seeds."""
+    all_results: list[RunResult] = []
+
+    for config in CONFIGS:
+        for run_idx in range(RUNS_PER_CONFIG):
+            seed = SEED_BASE + run_idx
+            result = run_single(config, seed)
+            all_results.append(result)
+
+    # Aggregate by config
+    config_stats: dict[str, dict[str, Any]] = {}
+    for config in CONFIGS:
+        name = config["name"]
+        results = [r for r in all_results if r.config_name == name]
+        final_bests = [r.final_best for r in results]
+        final_avgs = [r.final_avg for r in results]
+        improvements = [r.improvement for r in results]
+        final_diversities = [r.diversity_per_gen[-1] for r in results]
+
+        config_stats[name] = {
+            "config": config,
+            "final_best_mean": statistics.mean(final_bests),
+            "final_best_std": statistics.stdev(final_bests) if len(final_bests) > 1 else 0.0,
+            "final_avg_mean": statistics.mean(final_avgs),
+            "final_avg_std": statistics.stdev(final_avgs) if len(final_avgs) > 1 else 0.0,
+            "improvement_mean": statistics.mean(improvements),
+            "improvement_std": statistics.stdev(improvements) if len(improvements) > 1 else 0.0,
+            "final_diversity_mean": statistics.mean(final_diversities),
+        }
+
+    # Cross-config spread
+    best_means = [s["final_best_mean"] for s in config_stats.values()]
+    avg_means = [s["final_avg_mean"] for s in config_stats.values()]
+    improvement_means = [s["improvement_mean"] for s in config_stats.values()]
+
+    best_spread = max(best_means) - min(best_means)
+    avg_spread = max(avg_means) - min(avg_means)
+    improvement_spread = max(improvement_means) - min(improvement_means)
+
+    # Relative spreads (as % of the mean)
+    best_mean_overall = statistics.mean(best_means)
+    avg_mean_overall = statistics.mean(avg_means)
+
+    best_relative_spread = (best_spread / best_mean_overall * 100) if best_mean_overall > 0 else 0
+    avg_relative_spread = (avg_spread / avg_mean_overall * 100) if avg_mean_overall > 0 else 0
+
+    return {
+        "config_stats": config_stats,
+        "cross_config": {
+            "best_spread": best_spread,
+            "avg_spread": avg_spread,
+            "improvement_spread": improvement_spread,
+            "best_relative_spread_pct": best_relative_spread,
+            "avg_relative_spread_pct": avg_relative_spread,
+        },
+        "threshold": 10.0,  # ADR 0005 §6 threshold
+    }
+
+
+def print_report(results: dict[str, Any]) -> None:
+    """Print a human-readable report."""
+    cross = results["cross_config"]
+    threshold = results["threshold"]
+
+    print("=" * 70)
+    print("PBT FEASIBILITY SPIKE — RESULTS")
+    print("=" * 70)
+    print()
+    print(f"Population size: {POPULATION_SIZE}")
+    print(f"Generations: {GENERATIONS}")
+    print(f"Runs per config: {RUNS_PER_CONFIG}")
+    print(f"Configs tested: {len(CONFIGS)}")
+    print(f"Fitness dimensions: {FITNESS_DIMENSIONS}")
+    print()
+
+    print("PER-CONFIG RESULTS:")
+    print("-" * 70)
+    for name, stats in results["config_stats"].items():
+        cfg = stats["config"]
+        print(f"\n  [{name}]")
+        print(
+            f"    tournament_size={cfg['tournament_size']}, elitism={cfg['elitism']}, "
+            f"mutation_rate={cfg['mutation_rate']}, mutation_mag={cfg['mutation_mag']}"
+        )
+        print(
+            f"    Final best fitness: {stats['final_best_mean']:.4f} ± {stats['final_best_std']:.4f}"
+        )
+        print(
+            f"    Final avg fitness:  {stats['final_avg_mean']:.4f} ± {stats['final_avg_std']:.4f}"
+        )
+        print(
+            f"    Improvement:        {stats['improvement_mean']:.4f} ± {stats['improvement_std']:.4f}"
+        )
+        print(f"    Final diversity:    {stats['final_diversity_mean']:.4f}")
+
+    print()
+    print("CROSS-CONFIG SPREAD:")
+    print("-" * 70)
+    print(
+        f"  Best fitness spread:       {cross['best_spread']:.4f} ({cross['best_relative_spread_pct']:.1f}%)"
+    )
+    print(
+        f"  Average fitness spread:    {cross['avg_spread']:.4f} ({cross['avg_relative_spread_pct']:.1f}%)"
+    )
+    print(f"  Improvement spread:        {cross['improvement_spread']:.4f}")
+    print()
+
+    # Verdict
+    best_pct = cross["best_relative_spread_pct"]
+    avg_pct = cross["avg_relative_spread_pct"]
+    exceeds = best_pct > threshold or avg_pct > threshold
+
+    print("VERDICT:")
+    print("-" * 70)
+    if exceeds:
+        verdict = "VALIDATED"
+        recommendation = (
+            "Hyperparameter variance produces meaningful outcome differences "
+            f"(best spread {best_pct:.1f}% / avg spread {avg_pct:.1f}% > {threshold}% threshold). "
+            "PBT is justified — proceed to design doc with concrete integration points."
+        )
+    else:
+        verdict = "INVALIDATED"
+        recommendation = (
+            f"Hyperparameter spread is below {threshold}% threshold "
+            f"(best {best_pct:.1f}%, avg {avg_pct:.1f}%). "
+            "The current hyperparameter space may be too narrow for PBT to add value. "
+            "Consider: (1) expanding the tunable surface, (2) testing on real LLM-generated "
+            "fitness landscapes where mutation quality varies more, or (3) closing this item "
+            "as 'explored, not worth the complexity'."
+        )
+
+    print(f"  {verdict}")
+    print(f"  {recommendation}")
+    print()
+
+
+def main() -> None:
+    results = run_spike()
+    print_report(results)
+
+    # Write raw results to JSON
+    output_path = Path(__file__).parent / "results.json"
+    # Convert to serializable form
+    serializable = {
+        "cross_config": results["cross_config"],
+        "threshold": results["threshold"],
+        "config_stats": {},
+    }
+    for name, stats in results["config_stats"].items():
+        serializable["config_stats"][name] = {k: v for k, v in stats.items() if k != "config"}
+        serializable["config_stats"][name]["config"] = {
+            k: v for k, v in stats["config"].items() if k != "name"
+        }
+
+    with open(output_path, "w") as f:
+        json.dump(serializable, f, indent=2)
+    print(f"Raw results written to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Runs a feasibility spike for Population-Based Training (PBT) as recommended by ADR 0005 §6. Exercises the selection + mutation loop with 5 hyperparameter configs × 5 random seeds × 10 generations on synthetic fitness landscapes.

## Results

| Config | Tournament | Elitism | Mut Rate | Mut Mag | Final Best | Improvement |
|--------|-----------|---------|----------|---------|------------|-------------|
| baseline | 3 | 1 | 0.10 | 0.05 | 0.708 ± 0.039 | +0.025 |
| exploratory | 2 | 0 | 0.30 | 0.15 | 0.848 ± 0.066 | +0.165 |
| exploitative | 7 | 3 | 0.05 | 0.02 | 0.680 ± 0.022 | −0.003 |
| balanced | 4 | 2 | 0.15 | 0.08 | 0.744 ± 0.058 | +0.061 |
| conservative | 3 | 5 | 0.05 | 0.03 | 0.686 ± 0.030 | +0.003 |

**Cross-config spread:** Best fitness 22.9% (threshold: 10%). **Verdict: VALIDATED.**

Key finding: "exploratory" config achieved 24.7% higher best fitness than "exploitative" — exactly the explore-exploit tradeoff PBT is designed to navigate.

## Addresses

TODO.md P3: "Run PBT feasibility spike" (follow-up from ADR 0005 §6)

## Verification

- `ruff format --check .` ✅
- `ruff check evoseal/ tests/` ✅
- Spike script runs standalone (`python spikes/pbt-feasibility/spike.py`) ✅
- No Python under `evoseal/` or `tests/` changed (docs + spike script + TODO.md only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a feasibility evaluation for evolutionary optimization across multiple configurations and random seeds.
  - Added benchmark results covering fitness, diversity, variation, and configuration performance.
  - Added a validated directional recommendation and suggested next steps based on the evaluation.

- **Documentation**
  - Marked the feasibility spike as completed and updated project tracking totals.
  - Documented the evaluation method, threshold, results, caveats, verdict, and related materials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->