### PR TITLE
docs: resolve DGM/OpenEvolve adapter drift — document canonical adapters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -142,7 +142,7 @@
 
 ### DGM/OpenEvolve Adapter Issues Found in Whole-Repo Code Review (2026-07-22)
 
-- [ ] **`evoseal/integration/dgm/` + `dgmr/` and `evoseal/integration/oe/` + `openevolve/` look like duplicated/forked adapter implementations that have drifted apart** — needs a decision on which is canonical and whether the other should be removed or reconciled
+- [x] **`evoseal/integration/dgm/` + `dgmr/` and `evoseal/integration/oe/` + `openevolve/` look like duplicated/forked adapter implementations that have drifted apart** _(done 2026-08-08)_ — analyzed both subsystems: `dgmr/` is the canonical DGM adapter (remote HTTP, used by orchestrator + all tests); `dgm/` is a legacy local adapter retained for one regression test; `oe/` is the canonical OpenEvolve adapter; `openevolve/` was broken dead code (imported from a nonexistent module). Added deprecation notices to legacy adapters, fixed broken `openevolve/__init__.py`. See `docs/integration/adapter_consolidation.md`.
 - [x] **DGM/OpenEvolve job runner reports failed jobs as successful** _(done 2026-08-07, refined per review feedback)_ — both `dgmr/dgm_adapter.py` `_advance_generation()` and `oe/openevolve_adapter.py` `_evolve_remote()` broke out of the poll loop on `status == "failed"` but then unconditionally fetched the result and returned `{"success": True}`. Fixed both to check the final status after the poll and return `success: False` with the error message when the job failed. Inverted check to `!= "completed"` so any non-terminal state (timeouts, unknown statuses) is also treated as failure. Added regression tests in `test_dgm_adapter_remote.py` and `test_openevolve_adapter_remote.py`.
 
 ### CLI Issues Found in Whole-Repo Code Review (2026-07-22)
@@ -307,7 +307,7 @@
 | Priority | Total | Done | Notes |
 |----------|-------|------|-------|
 | 🔴 P0    | 11    | 11   | Original 5 complete; all 6 critical bugs from 2026-07-22 whole-repo review fixed (PRs #74, #76-#79) |
-| 🟠 P1    | 24    | 19   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix; DGM/OE job runner failed-status bug fix |
+| 🟠 P1    | 24    | 19   | Original safety/integration items done; +12 high-priority bugs from 2026-07-22 review (3 CI/CD pipeline fixes: workflow_run name mismatch, requirements/ path, security gate bypass); signal-handler init fix; safety.yaml created; monitoring dashboard auth+CORS fix; DGM/OE job runner failed-status bug fix; DGM/OE adapter drift resolved |
 | 🟡 P2    | 30    | 25   | Co-evolution loop gaps (8 items, 8 done) + existing P2 + 13 medium bugs from 2026-07-22 review + 4 latent collect->train bugs found closing the loop (1 fixed, 1 new HF-format gap resolved); provider_manager health-check await fix; workflow-agent private-API/event-loop fix; checkpoint save/restore test; trust_remote_code security fix; safety-decision orchestration tests; structured improvement units |
 | 🟢 P3    | 26    | 20   | Makefile, pre-commit, Docker, ADRs, ADR refresh, CHANGELOG complete; +11 hygiene items from 2026-07-22 review; Ollama provider retry/backoff fix; local_models TTL cache; workspace prompt file conventions; how-it-works tutorial; model_fine_tuner key validation; model_fine_tuner GPU availability check; PBT exploration ADR |
 | **Total** | **91** | **75** | |

--- a/docs/integration/adapter_consolidation.md
+++ b/docs/integration/adapter_consolidation.md
@@ -1,0 +1,62 @@
+# DGM/OpenEvolve Adapter Consolidation
+
+> **Date:** 2026-08-08
+> **Status:** Analysis complete — canonical adapters identified
+
+## Problem
+
+EVOSEAL has two adapter layouts for each of DGM and OpenEvolve that have
+drifted apart:
+
+| Component | Legacy adapter | Canonical adapter |
+|-----------|---------------|-------------------|
+| DGM | `evoseal.integration.dgm` | `evoseal.integration.dgmr` |
+| OpenEvolve | `evoseal.integration.openevolve` | `evoseal.integration.oe` |
+
+This creates confusion about which to import and risks new code targeting the
+wrong module.
+
+## Analysis
+
+### DGM
+
+- **`evoseal/integration/dgmr/dgm_adapter.py`** (canonical) — a remote HTTP
+  adapter implementing `BaseComponentAdapter`. Used by the orchestrator
+  (`orchestrator.py`), the public `__init__.py`, and all recent unit tests
+  (`test_dgm_adapter_remote.py`, `test_orchestrator_smoke.py`,
+  `test_dry_run_mode.py`).
+
+- **`evoseal/integration/dgm/evolution_manager.py`** (legacy) — a local adapter
+  that directly imports the `dgm/` git submodule (`from dgm import DGM_outer`).
+  Used only by `tests/regression/test_regression_evolution.py`, which mocks the
+  submodule import. Also contains `data_adapter.py` (used only by
+  `EvolutionManager`).
+
+**Recommendation:** Keep `dgmr/` as the sole canonical adapter. `dgm/` is
+retained for the one regression test but should not be used by new code.
+Deprecation notices have been added to `dgm/evolution_manager.py` and
+`dgm/data_adapter.py`.
+
+### OpenEvolve
+
+- **`evoseal/integration/oe/openevolve_adapter.py`** (canonical) — a remote HTTP
+  adapter implementing `BaseComponentAdapter`. Used by the orchestrator, the
+  public `__init__.py`, and all tests.
+
+- **`evoseal/integration/openevolve/__init__.py`** (broken) — attempted to
+  `from .openevolve_adapter import OpenEvolveAdapter`, but no such file exists
+  in this directory. Any `import evoseal.integration.openevolve` would raise
+  `ImportError`. Nothing in production code imports from this package.
+
+**Recommendation:** Keep `oe/` as the sole canonical adapter. The broken
+`openevolve/__init__.py` has been fixed to a safe empty module with a
+deprecation notice.
+
+## Decision
+
+| Package | Action | Reason |
+|---------|--------|--------|
+| `dgmr/` | **Canonical** | Production adapter, orchestrator + tests |
+| `dgm/` | Deprecated (kept) | Legacy, one regression test consumer |
+| `oe/` | **Canonical** | Production adapter, orchestrator + tests |
+| `openevolve/` | Deprecated (fixed) | Was broken, no consumers |

--- a/evoseal/integration/dgm/data_adapter.py
+++ b/evoseal/integration/dgm/data_adapter.py
@@ -7,9 +7,15 @@ from evoseal.models.evaluation import EvaluationResult, TestCaseResult
 
 
 class DGMDataAdapter:
-    """
-    Adapter to bridge DGM run outputs (code, metadata, metrics) into structured EVOSEAL models.
-    Provides methods to convert, save, and load CodeArchive and EvaluationResult objects from disk.
+    """Adapter to bridge DGM run outputs into structured EVOSEAL models.
+
+    Provides methods to convert, save, and load CodeArchive and EvaluationResult
+    objects from disk.
+
+    .. deprecated::
+        This module is part of the legacy local DGM adapter (``evoseal.integration.dgm``).
+        The canonical adapter is ``evoseal.integration.dgmr``. This module is retained
+        only because ``dgm.evolution_manager.EvolutionManager`` uses it.
     """
 
     def __init__(self, base_dir: str):

--- a/evoseal/integration/dgm/data_adapter.py
+++ b/evoseal/integration/dgm/data_adapter.py
@@ -15,7 +15,7 @@ class DGMDataAdapter:
     .. deprecated::
         This module is part of the legacy local DGM adapter (``evoseal.integration.dgm``).
         The canonical adapter is ``evoseal.integration.dgmr``. This module is retained
-        only because ``dgm.evolution_manager.EvolutionManager`` uses it.
+        only because ``evoseal.integration.dgm.evolution_manager.EvolutionManager`` uses it.
     """
 
     def __init__(self, base_dir: str):

--- a/evoseal/integration/dgm/evolution_manager.py
+++ b/evoseal/integration/dgm/evolution_manager.py
@@ -7,7 +7,7 @@ EvolutionManager wrapper for DGM_outer procedural logic.
     (remote HTTP adapter), which is used by the orchestrator and all production code.
     This module is retained only for the regression test in
     ``tests/regression/test_regression_evolution.py``. New code should use
-    ``dgmr.dgm_adapter`` instead.
+    ``evoseal.integration.dgmr.dgm_adapter.DGMAdapter`` instead.
 
 This class provides an object-oriented interface for evolutionary management using the DGM submodule,
 without modifying the original DGM codebase.

--- a/evoseal/integration/dgm/evolution_manager.py
+++ b/evoseal/integration/dgm/evolution_manager.py
@@ -1,5 +1,14 @@
 """
 EvolutionManager wrapper for DGM_outer procedural logic.
+
+.. deprecated::
+    This module is a legacy local adapter that wraps the DGM submodule directly.
+    The canonical DGM adapter is ``evoseal.integration.dgmr.dgm_adapter.DGMAdapter``
+    (remote HTTP adapter), which is used by the orchestrator and all production code.
+    This module is retained only for the regression test in
+    ``tests/regression/test_regression_evolution.py``. New code should use
+    ``dgmr.dgm_adapter`` instead.
+
 This class provides an object-oriented interface for evolutionary management using the DGM submodule,
 without modifying the original DGM codebase.
 

--- a/evoseal/integration/openevolve/__init__.py
+++ b/evoseal/integration/openevolve/__init__.py
@@ -1,5 +1,11 @@
-"""OpenEvolve integration module for EVOSEAL."""
+"""OpenEvolve integration package (legacy).
 
-from .openevolve_adapter import OpenEvolveAdapter, create_openevolve_adapter
+.. deprecated::
+    This package is a leftover from an earlier adapter layout. The canonical
+    OpenEvolve adapter is ``evoseal.integration.oe.openevolve_adapter``.
+    This package's ``__init__.py`` previously attempted to import from a
+    nonexistent ``.openevolve_adapter`` module, which raised ``ImportError``
+    on any import. New code should import from ``evoseal.integration.oe``.
+"""
 
-__all__ = ["OpenEvolveAdapter", "create_openevolve_adapter"]
+__all__: list[str] = []


### PR DESCRIPTION
## What

Analyzed the duplicate/forked adapter layout in `evoseal/integration/` and documented which adapters are canonical vs legacy.

## Findings

| Component | Legacy | Canonical | Evidence |
|-----------|--------|-----------|----------|
| DGM | `dgm/` | `dgmr/` | Orchestrator, `__init__.py`, all recent tests use `dgmr/` |
| OpenEvolve | `openevolve/` | `oe/` | Orchestrator, `__init__.py`, all tests use `oe/` |

- **`dgm/evolution_manager.py`** — legacy local adapter wrapping the DGM submodule directly. Only consumer: `tests/regression/test_regression_evolution.py`.
- **`openevolve/__init__.py`** — was broken dead code (tried to import from a nonexistent `.openevolve_adapter` module, causing `ImportError` on any import).

## Changes

- Added deprecation notices to `dgm/evolution_manager.py` and `dgm/data_adapter.py`
- Fixed broken `openevolve/__init__.py` (safe empty module with deprecation notice)
- Added `docs/integration/adapter_consolidation.md` with full analysis
- Updated TODO.md checkbox + tracking table

## Verification

- `ruff format --check .` — ✅
- `ruff check evoseal/ tests/` — ✅

Closes the DGM/OE adapter drift item in TODO.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the canonical DGM and OpenEvolve adapter locations.
  * Documented legacy adapters, their status, and migration recommendations.
  * Updated project tracking notes to reflect the resolved adapter inconsistency.

* **Bug Fixes**
  * Repaired the OpenEvolve integration initializer to remove failing imports.
  * Added deprecation notices directing new integrations to supported adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->